### PR TITLE
Fix typo of link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### PLASMA MVP WIP
 
-We're implementing the [Minimum Viable Plasma](https://ethresear.ch/t/minimal-viable-plasma/426.)
+We're implementing the [Minimum Viable Plasma](https://ethresear.ch/t/minimal-viable-plasma/426)
 
 
 Current repo includes:


### PR DESCRIPTION
Fix typo of link [Minimum Viable Plasma](https://ethresear.ch/t/minimal-viable-plasma/426.) to [Minimum Viable Plasma](https://ethresear.ch/t/minimal-viable-plasma/426) 

removed tailing `.`