### PR TITLE
Optimize root chain

### DIFF
--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -45,7 +45,8 @@ class Client(object):
         self.child_chain.submit_block(block)
 
     def withdraw(self, txPos, tx, proof, sigs):
-        self.root_chain.startExit(txPos, rlp.encode(tx, UnsignedTransaction), proof, sigs, transact={'from': '0x' + tx.newowner1.hex()})
+        utxoPos = txPos[0] * 1000000000 + txPos[1] * 10000 * txPos[2] + 0
+        self.root_chain.startExit(utxoPos, rlp.encode(tx, UnsignedTransaction), proof, sigs, transact={'from': '0x' + tx.newowner1.hex()})
 
     def get_transaction(self, blknum, txindex):
         return self.child_chain.get_transaction(blknum, txindex)

--- a/plasma/root_chain/contracts/Libraries/RLP.sol
+++ b/plasma/root_chain/contracts/Libraries/RLP.sol
@@ -189,13 +189,12 @@ library RLP {
  }
 
  /// @dev Get the list of sub-items from an RLP encoded list.
- /// Warning: This is inefficient, as it requires that the list is read twice.
+ /// Warning: This requires passing in the number of items.
  /// @param self The RLP item.
  /// @return Array of RLPItems.
- function toList(RLPItem memory self) internal constant returns (RLPItem[] memory list) {
+ function toList(RLPItem memory self, uint256 numItems) internal constant returns (RLPItem[] memory list) {
      if(!isList(self))
          throw;
-     var numItems = items(self);
      list = new RLPItem[](numItems);
      var it = iterator(self);
      uint idx;

--- a/plasma/root_chain/contracts/Libraries/Validate.sol
+++ b/plasma/root_chain/contracts/Libraries/Validate.sol
@@ -13,7 +13,7 @@ library Validate {
         bytes memory sig1 = ByteUtils.slice(sigs, 0, 65);
         bytes memory sig2 = ByteUtils.slice(sigs, 65, 65);
         bytes memory confSig1 = ByteUtils.slice(sigs, 130, 65);
-        bytes32 confirmationHash = keccak256(txHash, sig1, sig2, rootHash);
+        bytes32 confirmationHash = keccak256(txHash, rootHash);
         if (inputCount == 0) {
             return msg.sender == ECRecovery.recover(confirmationHash, confSig1);
         }

--- a/plasma/root_chain/contracts/Libraries/Validate.sol
+++ b/plasma/root_chain/contracts/Libraries/Validate.sol
@@ -17,7 +17,7 @@ library Validate {
         if (inputCount == 0) {
             return msg.sender == ECRecovery.recover(confirmationHash, confSig1);
         }
-        if (inputCount < 1000000) {
+        if (inputCount < 1000000000) {
             return ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
         } else {
             bytes memory confSig2 = ByteUtils.slice(sigs, 195, 65);

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -7,6 +7,12 @@ import 'Validate.sol';
 import 'PriorityQueue.sol';
 
 
+/**
+ * @title RootChain
+ * @dev This contract secures a utxo payments plasma child chain to ethereum
+ */
+
+
 contract RootChain {
     using SafeMath for uint256;
     using RLP for bytes;
@@ -18,6 +24,7 @@ contract RootChain {
      * Events
      */
     event Deposit(address depositor, uint256 amount);
+    event Exit(address exitor, uint256 utxoPos);
 
     /*
      *  Storage
@@ -28,14 +35,13 @@ contract RootChain {
     PriorityQueue exitsQueue;
     address public authority;
     uint256 public currentChildBlock;
-    uint256 public lastParentBlock;
     uint256 public recentBlock;
     uint256 public weekOldBlock;
 
     struct exit {
         address owner;
         uint256 amount;
-        uint256[3] utxoPos;
+        uint256 utxoPos;
     }
 
     struct childBlock {
@@ -65,29 +71,33 @@ contract RootChain {
     {
         authority = msg.sender;
         currentChildBlock = 1;
-        lastParentBlock = block.number;
         exitsQueue = new PriorityQueue();
     }
 
-    function submitBlock(bytes32 root)
+    // @dev Allows Plasma chain operator to submit block root
+    // @param root The root of a child chain block
+    function submitBlock(bytes32 root, uint256 blknum)
         public
         isAuthority
         incrementOldBlocks
     {
-        require(block.number >= lastParentBlock.add(6));
+        require(blknum == currentChildBlock);
         childChain[currentChildBlock] = childBlock({
             root: root,
             created_at: block.timestamp
         });
         currentChildBlock = currentChildBlock.add(1);
-        lastParentBlock = block.number;
     }
 
+    // @dev Allows anyone to deposit funds into the Plasma chain
+    // @param txBytes The format of the transaction that'll become the deposit
+    // TODO: This needs to be optimized so that the transaction is created
+    //       from msg.sender and msg.value
     function deposit(bytes txBytes)
         public
         payable
     {
-        var txList = txBytes.toRLPItem().toList();
+        var txList = txBytes.toRLPItem().toList(11);
         require(txList.length == 11);
         for (uint256 i; i < 6; i++) {
             require(txList[i].toUint() == 0);
@@ -108,6 +118,93 @@ contract RootChain {
         Deposit(txList[6].toAddress(), txList[7].toUint());
     }
 
+    // @dev Starts to exit a specified utxo
+    // @param utxoPos The position of the exiting utxo in the format of blknum * 1000000000 + index * 10000 + oindex
+    // @param txBytes The transaction being exited in RLP bytes format
+    // @param proof Proof of the exiting transactions inclusion for the block specified by utxoPos
+    // @param sigs Both transaction signatures and confirmations signatures used to verify that the exiting transaction has been confirmed
+    function startExit(uint256 utxoPos, bytes txBytes, bytes proof, bytes sigs)
+        public
+        incrementOldBlocks
+    {
+        var txList = txBytes.toRLPItem().toList(11);
+        uint256 blknum = utxoPos / 1000000000;
+        uint256 txindex = (utxoPos % 1000000000) / 10000;
+        uint256 oindex = utxoPos - blknum * 1000000000 - txindex * 10000;
+        bytes32 root = childChain[blknum].root;
+
+        require(msg.sender == txList[6 + 2 * oindex].toAddress());
+        bytes32 txHash = keccak256(txBytes);
+        bytes32 merkleHash = keccak256(txHash, ByteUtils.slice(sigs, 0, 130));
+        uint256 inputCount = txList[3].toUint() * 1000000000 + txList[0].toUint();
+        require(Validate.checkSigs(txHash, root, inputCount, sigs));
+        require(merkleHash.checkMembership(txindex, root, proof));
+
+        // Priority is a given utxos position in the exit priority queue
+        uint256 priority;
+        if (blknum < weekOldBlock) {
+            priority = (utxoPos / blknum).mul(weekOldBlock);
+        } else {
+            priority = utxoPos;
+        }
+        require(exitIds[utxoPos] == 0);
+        exitIds[utxoPos] = priority;
+        exitsQueue.insert(priority);
+        exits[priority] = exit({
+            owner: txList[6 + 2 * oindex].toAddress(),
+            amount: txList[7 + 2 * oindex].toUint(),
+            utxoPos: utxoPos
+        });
+        Exit(msg.sender, utxoPos);
+    }
+
+    // @dev Allows anyone to challenge an exiting transaction by submitting proof of a double spend on the child chain
+    // @param cUtxoPos The position of the challenging utxo
+    // @param eUtxoPos The position of the exiting utxo
+    // @param txBytes The challenging transaction in bytes RLP form
+    // @param proof Proof of inclusion for the transaction used to challenge
+    // @param sigs Signatures for the transaction used to challenge
+    // @param confirmationSig The confirmation signature for the transaction used to challenge
+    function challengeExit(uint256 cUtxoPos, uint256 eUtxoPos, bytes txBytes, bytes proof, bytes sigs, bytes confirmationSig)
+        public
+    {
+        uint256 txindex = (cUtxoPos % 1000000000) / 10000;
+        bytes32 root = childChain[cUtxoPos / 1000000000].root;
+        uint256 priority = exitIds[eUtxoPos];
+        var txHash = keccak256(txBytes);
+        var confirmationHash = keccak256(txHash, root);
+        var merkleHash = keccak256(txHash, sigs);
+        address owner = exits[priority].owner;
+
+        require(owner == ECRecovery.recover(confirmationHash, confirmationSig));
+        require(merkleHash.checkMembership(txindex, root, proof));
+        delete exits[priority];
+        delete exitIds[eUtxoPos];
+    }
+
+
+    // @dev Loops through the priority queue of exits, settling the ones whose challenge
+    // @dev challenge period has ended
+    function finalizeExits()
+        public
+        incrementOldBlocks
+        returns (uint256)
+    {
+        uint256 twoWeekOldTimestamp = block.timestamp.sub(2 weeks);
+        exit memory currentExit = exits[exitsQueue.getMin()];
+        uint256 blknum = currentExit.utxoPos.div(1000000000);
+        while (childChain[blknum].created_at < twoWeekOldTimestamp && exitsQueue.currentSize() > 0) {
+            currentExit.owner.transfer(currentExit.amount);
+            uint256 priority = exitsQueue.delMin();
+            delete exits[priority];
+            delete exitIds[currentExit.utxoPos];
+            currentExit = exits[exitsQueue.getMin()];
+        }
+    }
+
+    /* 
+     *  Constants
+     */
     function getChildChain(uint256 blockNumber)
         public
         view
@@ -119,72 +216,8 @@ contract RootChain {
     function getExit(uint256 priority)
         public
         view
-        returns (address, uint256, uint256[3])
+        returns (address, uint256, uint256)
     {
         return (exits[priority].owner, exits[priority].amount, exits[priority].utxoPos);
-    }
-
-    function startExit(uint256[3] txPos, bytes txBytes, bytes proof, bytes sigs)
-        public
-        incrementOldBlocks
-    {
-        var txList = txBytes.toRLPItem().toList();
-        require(txList.length == 11);
-        require(msg.sender == txList[6 + 2 * txPos[2]].toAddress());
-        bytes32 txHash = keccak256(txBytes);
-        bytes32 merkleHash = keccak256(txHash, ByteUtils.slice(sigs, 0, 130));
-        uint256 inputCount = txList[3].toUint() * 1000000 + txList[0].toUint();
-        require(Validate.checkSigs(txHash, childChain[txPos[0]].root, inputCount, sigs));
-        require(merkleHash.checkMembership(txPos[1], childChain[txPos[0]].root, proof));
-        uint256 priority = 1000000000 + txPos[1] * 10000 + txPos[2];
-        uint256 exitId = txPos[0].mul(priority);
-        priority = priority.mul(Math.max(txPos[0], weekOldBlock));
-        require(exitIds[exitId] == 0);
-        require(exits[priority].amount == 0);
-        exitIds[exitId] = priority;
-        exitsQueue.insert(priority);
-        exits[priority] = exit({
-            owner: txList[6 + 2 * txPos[2]].toAddress(),
-            amount: txList[7 + 2 * txPos[2]].toUint(),
-            utxoPos: txPos
-        });
-    }
-
-    function challengeExit(uint256 exitId, uint256[3] txPos, bytes txBytes, bytes proof, bytes sigs, bytes confirmationSig)
-        public
-    {
-        var txList = txBytes.toRLPItem().toList();
-        require(txList.length == 11);
-        uint256 priority = exitIds[exitId];
-        uint256[3] memory exitsUtxoPos = exits[priority].utxoPos;
-        require(exitsUtxoPos[0] == txList[0 + 2 * exitsUtxoPos[2]].toUint());
-        require(exitsUtxoPos[1] == txList[1 + 2 * exitsUtxoPos[2]].toUint());
-        require(exitsUtxoPos[2] == txList[2 + 2 * exitsUtxoPos[2]].toUint());
-        var txHash = keccak256(txBytes);
-        var confirmationHash = keccak256(txHash, sigs, childChain[txPos[0]].root);
-        var merkleHash = keccak256(txHash, sigs);
-        address owner = exits[priority].owner;
-        require(owner == ECRecovery.recover(confirmationHash, confirmationSig));
-        require(merkleHash.checkMembership(txPos[1], childChain[txPos[0]].root, proof));
-        delete exits[priority];
-        delete exitIds[exitId];
-    }
-
-    function finalizeExits()
-        public
-        incrementOldBlocks
-        returns (uint256)
-    {
-        uint256 twoWeekOldTimestamp = block.timestamp.sub(2 weeks);
-        exit memory currentExit = exits[exitsQueue.getMin()];
-        while (childChain[currentExit.utxoPos[0]].created_at < twoWeekOldTimestamp && exitsQueue.currentSize() > 0) {
-            // return childChain[currentExit.utxoPos[0]].created_at;
-            uint256 exitId = currentExit.utxoPos[0] * 1000000000 + currentExit.utxoPos[1] * 10000 + currentExit.utxoPos[2];
-            currentExit.owner.transfer(currentExit.amount);
-            uint256 priority = exitsQueue.delMin();
-            delete exits[priority];
-            delete exitIds[exitId];
-            currentExit = exits[exitsQueue.getMin()];
-        }
     }
 }

--- a/plasma/utils/utils.py
+++ b/plasma/utils/utils.py
@@ -21,7 +21,7 @@ ZEROS_BYTES = [b'\x00' * 32]
 
 
 def confirm_tx(tx, root, key):
-    return sign(u.sha3(tx.hash + tx.sig1 + tx.sig2 + root), key)
+    return sign(u.sha3(tx.hash + root), key)
 
 
 def sign(hash, key):

--- a/tests/child_chain/test_child_chain.py
+++ b/tests/child_chain/test_child_chain.py
@@ -1,70 +1,70 @@
 import rlp
 import pytest
+from ethereum import utils as u
 from plasma.child_chain.transaction import Transaction
 from plasma.child_chain.block import Block
 from plasma.child_chain.child_chain import ChildChain
 
+
+key1 = u.normalize_key(b'8b76243a95f959bf101248474e6bdacdedc8ad995d287c24616a41bd51642965')
+invalid_key = u.normalize_key(b'8a76243a95f959bf101248474e6bdacdedc8ad995d287c24616a41bd51642965')
+newowner1 = b'\x8cT\xa4\xa0\x17\x9f$\x80\x1fI\xf92-\xab<\x87\xeb\x19L\x9b'
+amount1 = 200
+amount2 = 400
+
+
 @pytest.fixture
 def root_chain(get_contract):
     return get_contract('RootChain/RootChain.sol')
+
 
 @pytest.fixture
 def child_chain(root_chain):
     child_chain = ChildChain(None, None, None)
 
     # Create some valid transations
-    key = b'8b76243a95f959bf101248474e6bdacdedc8ad995d287c24616a41bd51642965'
-    owner, amount1 = '0x8f2ecdd6103c0423f4c3e906666238936e81e538', 200
-    tx1 = Transaction(0, 0, 0, 0, 0, 0, owner, amount1, b'\x00' * 20, 0, 0)
-    tx2 = Transaction(0, 0, 0, 0, 0, 0, owner, amount1, b'\x00' * 20, 0, 0)
+    tx1 = Transaction(0, 0, 0, 0, 0, 0, newowner1, amount1, b'\x00' * 20, 0, 0)
+    tx2 = Transaction(0, 0, 0, 0, 0, 0, newowner1, amount1, b'\x00' * 20, 0, 0)
 
     # Create a block with those transactions
     child_chain.blocks[1] = Block([tx1, tx2])
 
     return child_chain
 
-def test_send_tx_with_sig(child_chain):
-    # Valid key
-    key = b'8b76243a95f959bf101248474e6bdacdedc8ad995d287c24616a41bd51642965'
 
-    newowner, amount2 = '0x4b3ec6c9dc67079e82152d6d55d8dd96a8e6aa26', 400
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner, amount2, b'\x00' * 20, 0, 0)
+def test_send_tx_with_sig(child_chain):
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
 
     # Sign the transaction
-    tx3.sign1(key)
-    tx3.sign2(key)
+    tx3.sign1(key1)
+    tx3.sign2(key1)
 
     child_chain.apply_transaction(rlp.encode(tx3).hex())
 
+
 def test_send_tx_no_sig(child_chain):
-    newowner, amount2 = '0x4b3ec6c9dc67079e82152d6d55d8dd96a8e6aa26', 400
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner, amount2, b'\x00' * 20, 0, 0)
-
-    with pytest.raises(ValueError):
-        child_chain.apply_transaction(rlp.encode(tx3).hex())
-
-def test_send_tx_invalid_sig(child_chain):
-    # Invalid key
-    key = b'8a76243a95f959bf101248474e6bdacdedc8ad995d287c24616a41bd51642965'
-
-    newowner, amount2 = '0x4b3ec6c9dc67079e82152d6d55d8dd96a8e6aa26', 400
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner, amount2, b'\x00' * 20, 0, 0)
-
-    # Sign with an invalid key
-    tx3.sign1(key)
-    tx3.sign2(key)
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
 
     with pytest.raises(AssertionError):
         child_chain.apply_transaction(rlp.encode(tx3).hex())
 
-def test_send_tx_double_spend(child_chain):
-    key = b'8b76243a95f959bf101248474e6bdacdedc8ad995d287c24616a41bd51642965'
 
-    newowner, amount2 = '0x4b3ec6c9dc67079e82152d6d55d8dd96a8e6aa26', 400
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner, amount2, b'\x00' * 20, 0, 0)
+def test_send_tx_invalid_sig(child_chain):
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
 
-    tx3.sign1(key)
-    tx3.sign2(key)
+    # Sign with an invalid key
+    tx3.sign1(invalid_key)
+    tx3.sign2(invalid_key)
+
+    with pytest.raises(AssertionError):
+        child_chain.apply_transaction(rlp.encode(tx3).hex())
+
+
+def test_send_tx_double_spend(child_chain, u):
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
+
+    tx3.sign1(key1)
+    tx3.sign2(key1)
 
     # Submit once
     child_chain.apply_transaction(rlp.encode(tx3).hex())


### PR DESCRIPTION
Change `txPos[3]` to a `utxoPos` unique id.
Reduce RLP `toList` gas costs.
Create exit event.
Add documentation to root chain smart contract.
Refactor child chain tests.
