### PR TITLE
add protection against reorgs

### DIFF
--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -44,6 +44,7 @@ contract RootChain {
     uint256 public currentDepositBlock; /* takes values in range 1..999 */
     uint256 public recentBlock;
     uint256 public weekOldBlock;
+    uint256 public childBlockInterval;
 
     struct exit {
         address owner;
@@ -83,7 +84,7 @@ contract RootChain {
         view
         returns (uint256)
     {
-        return value.div(1000).add(1).mul(1000);
+        return value.div(childBlockInterval).add(1).mul(childBlockInterval);
     }
 
     function getDepositBlock()
@@ -91,14 +92,15 @@ contract RootChain {
         view
         returns (uint256)
     {
-        return currentChildBlock.sub(1000).add(currentDepositBlock);
+        return currentChildBlock.sub(childBlockInterval).add(currentDepositBlock);
     }
 
     function RootChain()
         public
     {
         authority = msg.sender;
-        currentChildBlock = 1000;
+        childBlockInterval = 1000;
+        currentChildBlock = childBlockInterval;
         currentDepositBlock = 1;
         weekOldBlock = 1;
         exitsQueue = new PriorityQueue();
@@ -115,7 +117,7 @@ contract RootChain {
             root: root,
             created_at: block.timestamp
         });
-        currentChildBlock = currentChildBlock.add(1000);
+        currentChildBlock = currentChildBlock.add(childBlockInterval);
         currentDepositBlock = 1;
     }
 
@@ -127,7 +129,7 @@ contract RootChain {
         public
         payable
     {
-        require(currentDepositBlock < 1000);
+        require(currentDepositBlock < childBlockInterval);
         var txList = txBytes.toRLPItem().toList(11);
         require(txList.length == 11);
         for (uint256 i; i < 6; i++) {

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -34,6 +34,12 @@ contract RootChain {
     mapping(uint256 => uint256) public exitIds;
     PriorityQueue exitsQueue;
     address public authority;
+    /* Block numbering scheme below is needed to prevent Ethereum reorg from invalidating blocks submitted
+       by operator. Two mechanisms must be in place to prevent chain from crashing:
+       1) don't mine tx that spent fresh deposits; if they are reorged from existence, block is invalid
+       2) disappearance of submit block does not affect operator's block numbering; hence tx submitted by
+       users that address that block stay valid.
+    */
     uint256 public currentChildBlock; /* ends with 000 */
     uint256 public currentDepositBlock; /* takes values in range 1..999 */
     uint256 public recentBlock;

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -12,16 +12,23 @@ def root_chain(t, get_contract):
     return contract
 
 
+def testNextBlockNumber(t, root_chain):
+    assert 1000 == root_chain.nextWeekOldChildBlock(0)
+    assert 1000 == root_chain.nextWeekOldChildBlock(55)
+    assert 2000 == root_chain.nextWeekOldChildBlock(1000)
+    assert 2000 == root_chain.nextWeekOldChildBlock(1001)
+
+
 def test_deposit(t, root_chain):
     owner, value_1 = t.a1, 100
     null_address = b'\x00' * 20
     tx = Transaction(0, 0, 0, 0, 0, 0,
                      owner, value_1, null_address, 0, 0)
     tx_bytes = rlp.encode(tx, UnsignedTransaction)
+    blknum = root_chain.getDepositBlock()
     root_chain.deposit(tx_bytes, value=value_1)
-    assert root_chain.getChildChain(1)[0] == get_merkle_of_leaves(16, [tx.hash + tx.sig1 + tx.sig2]).root
-    assert root_chain.getChildChain(1)[1] == t.chain.head_state.timestamp
-    assert root_chain.currentChildBlock() == 2
+    assert root_chain.getChildChain(blknum)[0] == get_merkle_of_leaves(16, [tx.hash + tx.sig1 + tx.sig2]).root
+    assert root_chain.getChildChain(blknum)[1] == t.chain.head_state.timestamp
 
 
 def test_start_exit(t, root_chain, assert_tx_failed):
@@ -31,56 +38,63 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx_bytes1 = rlp.encode(tx1, UnsignedTransaction)
+    dep_blknum = root_chain.getDepositBlock()
+    assert dep_blknum == 1
     root_chain.deposit(tx_bytes1, value=value_1)
     merkle = FixedMerkle(16, [tx1.merkle_hash], True)
     proof = merkle.create_membership_proof(tx1.merkle_hash)
-    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(1)[0], key)
-    priority1 = 1 * 1000000000 + 10000 * 0 + 0
+    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep_blknum)[0], key)
+    priority1 = dep_blknum * 1000000000 + 10000 * 0 + 0
     snapshot = t.chain.snapshot()
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
-    utxoId = 1 * 1000000000 + 10000 * 0 + 0
+    utxoId = dep_blknum * 1000000000 + 10000 * 0 + 0
     # Deposit exit
     root_chain.startExit(utxoId, tx_bytes1, proof, sigs, sender=key)
 
     t.chain.head_state.timestamp += week_and_a_half
     # Cannot exit twice off of the same utxo
-    exitId1 = 1 * 1000000000 + 10000 * 0 + 0
+    exitId1 = dep_blknum * 1000000000 + 10000 * 0 + 0
     assert_tx_failed(lambda: root_chain.startExit(exitId1, tx_bytes1, proof, sigs, sender=key))
     assert root_chain.getExit(priority1) == ['0x' + owner.hex(), 100, exitId1]
     t.chain.revert(snapshot)
 
-    tx2 = Transaction(1, 0, 0, 0, 0, 0,
+    tx2 = Transaction(dep_blknum, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx2.sign1(key)
     tx_bytes2 = rlp.encode(tx2, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx2.merkle_hash], True)
     proof = merkle.create_membership_proof(tx2.merkle_hash)
-    root_chain.submitBlock(merkle.root, root_chain.currentChildBlock())
-    confirmSig1 = confirm_tx(tx2, root_chain.getChildChain(2)[0], key)
-    priority2 = 2 * 1000000000 + 10000 * 0 + 0
+    child_blknum = root_chain.currentChildBlock()
+    assert child_blknum == 1000
+    root_chain.submitBlock(merkle.root)
+    confirmSig1 = confirm_tx(tx2, root_chain.getChildChain(child_blknum)[0], key)
+    priority2 = child_blknum * 1000000000 + 10000 * 0 + 0
     sigs = tx2.sig1 + tx2.sig2 + confirmSig1
     snapshot = t.chain.snapshot()
-    # Single input exit
-    exitId2 = 2 * 1000000000 + 10000 * 0 + 0
+    # # Single input exit
+    exitId2 = child_blknum * 1000000000 + 10000 * 0 + 0
     root_chain.startExit(exitId2, tx_bytes2, proof, sigs, sender=key)
     assert root_chain.getExit(priority2) == ['0x' + owner.hex(), 100, exitId2]
     t.chain.revert(snapshot)
-
+    dep2_blknum = root_chain.getDepositBlock()
+    assert dep2_blknum == 1001
     root_chain.deposit(tx_bytes1, value=value_1)
-    tx3 = Transaction(2, 0, 0, 3, 0, 0,
+    tx3 = Transaction(child_blknum, 0, 0, dep2_blknum, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx3.sign1(key)
     tx3.sign2(key)
     tx_bytes3 = rlp.encode(tx3, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx3.merkle_hash], True)
     proof = merkle.create_membership_proof(tx3.merkle_hash)
-    root_chain.submitBlock(merkle.root, root_chain.currentChildBlock())
-    confirmSig1 = confirm_tx(tx3, root_chain.getChildChain(4)[0], key)
-    confirmSig2 = confirm_tx(tx3, root_chain.getChildChain(4)[0], key)
-    priority3 = 4 * 1000000000 + 10000 * 0 + 0
+    child2_blknum = root_chain.currentChildBlock()
+    assert child2_blknum == 2000
+    root_chain.submitBlock(merkle.root)
+    confirmSig1 = confirm_tx(tx3, root_chain.getChildChain(child2_blknum)[0], key)
+    confirmSig2 = confirm_tx(tx3, root_chain.getChildChain(child2_blknum)[0], key)
+    priority3 = child2_blknum * 1000000000 + 10000 * 0 + 0
     sigs = tx3.sig1 + tx3.sig2 + confirmSig1 + confirmSig2
     # Double input exit
-    exitId3 = 4 * 1000000000 + 10000 * 0 + 0
+    exitId3 = child2_blknum * 1000000000 + 10000 * 0 + 0
     root_chain.startExit(exitId3, tx_bytes3, proof, sigs, sender=key)
     assert root_chain.getExit(priority3) == ['0x' + owner.hex(), 100, exitId3]
 
@@ -91,23 +105,25 @@ def test_challenge_exit(t, u, root_chain):
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx_bytes1 = rlp.encode(tx1, UnsignedTransaction)
+    dep1_blknum = root_chain.getDepositBlock()
     root_chain.deposit(tx_bytes1, value=value_1)
     merkle = FixedMerkle(16, [tx1.merkle_hash], True)
     proof = merkle.create_membership_proof(tx1.merkle_hash)
-    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(1)[0], key)
+    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep1_blknum)[0], key)
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
-    exitId1 = 1 * 1000000000 + 10000 * 0 + 0
+    exitId1 = dep1_blknum * 1000000000 + 10000 * 0 + 0
     root_chain.startExit(exitId1, tx_bytes1, proof, sigs, sender=key)
-    tx2 = Transaction(1, 0, 0, 0, 0, 0,
+    tx2 = Transaction(dep1_blknum, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx2.sign1(key)
     tx_bytes2 = rlp.encode(tx2, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx2.merkle_hash], True)
     proof = merkle.create_membership_proof(tx2.merkle_hash)
-    root_chain.submitBlock(merkle.root, root_chain.currentChildBlock())
-    confirmSig = confirm_tx(tx2, root_chain.getChildChain(2)[0], key)
+    child_blknum = root_chain.currentChildBlock()
+    root_chain.submitBlock(merkle.root)
+    confirmSig = confirm_tx(tx2, root_chain.getChildChain(child_blknum)[0], key)
     sigs = tx2.sig1 + tx2.sig2
-    exitId2 = 2 * 1000000000 + 10000 * 0 + 0
+    exitId2 = child_blknum * 1000000000 + 10000 * 0 + 0
     assert root_chain.exits(exitId1) == ['0x' + owner.hex(), 100, exitId1]
     assert root_chain.exitIds(exitId1) == exitId1
     root_chain.challengeExit(exitId2, exitId1, tx_bytes2, proof, sigs, confirmSig)
@@ -122,12 +138,13 @@ def test_finalize_exits(t, u, root_chain):
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx_bytes1 = rlp.encode(tx1, UnsignedTransaction)
+    dep1_blknum = root_chain.getDepositBlock()
     root_chain.deposit(tx_bytes1, value=value_1)
     merkle = FixedMerkle(16, [tx1.merkle_hash], True)
     proof = merkle.create_membership_proof(tx1.merkle_hash)
-    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(1)[0], key)
+    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep1_blknum)[0], key)
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
-    exitId1 = 1 * 1000000000 + 10000 * 0 + 0
+    exitId1 = dep1_blknum * 1000000000 + 10000 * 0 + 0
     root_chain.startExit(exitId1, tx_bytes1, proof, sigs, sender=key)
     t.chain.head_state.timestamp += two_weeks * 2
     assert root_chain.exits(exitId1) == ['0x' + owner.hex(), 100, exitId1]

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -13,6 +13,7 @@ def root_chain(t, get_contract):
 
 
 def testNextBlockNumber(t, root_chain):
+    assert 1000 == root_chain.childBlockInterval()
     assert 1000 == root_chain.nextWeekOldChildBlock(0)
     assert 1000 == root_chain.nextWeekOldChildBlock(55)
     assert 2000 == root_chain.nextWeekOldChildBlock(1000)


### PR DESCRIPTION
Reorg probability being non-zero is a problem for plasma chain operator
since it may lead invalidation of block created by plasma operator.
Such event would lead to exit of all users. This change makes sure that
block number of block submitted by operator can't change because of reorg.

Implements David's "decimals for deposits" idea!