### PR TITLE
Alternate solution to inputCount

### DIFF
--- a/plasma/root_chain/contracts/Libraries/Validate.sol
+++ b/plasma/root_chain/contracts/Libraries/Validate.sol
@@ -4,7 +4,7 @@ import './ECRecovery.sol';
 
 
 library Validate {
-    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 inputCount, bytes sigs)
+    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 blknum1, uint256 blknum2, bytes sigs)
         internal
         view
         returns (bool)
@@ -14,16 +14,19 @@ library Validate {
         bytes memory sig2 = ByteUtils.slice(sigs, 65, 65);
         bytes memory confSig1 = ByteUtils.slice(sigs, 130, 65);
         bytes32 confirmationHash = keccak256(txHash, rootHash);
-        if (inputCount == 0) {
+
+        if (blknum1 == 0 && blknum2 == 0) {
             return msg.sender == ECRecovery.recover(confirmationHash, confSig1);
         }
-        if (inputCount < 1000000000) {
-            return ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
-        } else {
+        bool check1 = true;
+        bool check2 = true;
+        if (blknum1 > 0) {
+            check1 = ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
+        } 
+        if (blknum2 > 0) {
             bytes memory confSig2 = ByteUtils.slice(sigs, 195, 65);
-            bool check1 = ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
-            bool check2 = ECRecovery.recover(txHash, sig2) == ECRecovery.recover(confirmationHash, confSig2);
-            return check1 && check2;
+            check2 = ECRecovery.recover(txHash, sig2) == ECRecovery.recover(confirmationHash, confSig2);
         }
+        return check1 && check2;
     }
 }

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -136,8 +136,7 @@ contract RootChain {
         require(msg.sender == txList[6 + 2 * oindex].toAddress());
         bytes32 txHash = keccak256(txBytes);
         bytes32 merkleHash = keccak256(txHash, ByteUtils.slice(sigs, 0, 130));
-        uint256 inputCount = txList[3].toUint() * 1000000000 + txList[0].toUint();
-        require(Validate.checkSigs(txHash, root, inputCount, sigs));
+        require(Validate.checkSigs(txHash, root, txList[0].toUint(), txList[3].toUint(), sigs));
         require(merkleHash.checkMembership(txindex, root, proof));
 
         // Priority is a given utxos position in the exit priority queue


### PR DESCRIPTION
Here's another approach to determining how many inputs there are. It does fix the issue where eventually input 1 may have a large enough block number to be greater than 1 billion, but such a high block number is unlikely to be ever reached. A little cleaner of a solution, but either implementation should work fine.  