### PR TITLE
Change `exitIds` structure

### DIFF
--- a/plasma/root_chain/contracts/DataStructures/PriorityQueue.sol
+++ b/plasma/root_chain/contracts/DataStructures/PriorityQueue.sol
@@ -12,7 +12,7 @@ contract PriorityQueue {
         _;
     }
 
-    /* 
+    /*
      *  Storage
      */
     address owner;
@@ -27,7 +27,7 @@ contract PriorityQueue {
         currentSize = 0;
     }
 
-    function insert(uint256 k) 
+    function insert(uint256 k)
         public
         onlyOwner
     {
@@ -73,7 +73,15 @@ contract PriorityQueue {
         return retVal;
     }
 
-    function percUp(uint256 i) 
+    function isEmpty()
+        public
+        view
+        returns (bool)
+    {
+        return currentSize == 0;
+    }
+
+    function percUp(uint256 i)
         private
     {
         while (i.div(2) > 0) {

--- a/plasma/root_chain/contracts/Libraries/ArrayUtils.sol
+++ b/plasma/root_chain/contracts/Libraries/ArrayUtils.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.18;
+
+library ArrayUtils {
+    function remove(uint256[] storage _array, uint256 _value)
+        internal
+        returns (bool success)
+    {
+        int256 index = indexOf(_array, _value);
+        if (index == -1) {
+            return false;
+        }
+        uint256 lastElement = _array[_array.length - 1];
+        _array[uint256(index)] = lastElement;
+
+        delete _array[_array.length - 1];
+        _array.length -= 1;
+        return true;
+    }
+
+    function indexOf(uint256[] _array, uint256 _value)
+        internal
+        pure
+        returns(int256 index)
+    {
+        for (uint256 i = 0; i < _array.length; i++) {
+            if (_array[i] == _value) {
+                return int256(i);
+            }
+        }
+        return -1;
+    }
+}

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -256,12 +256,4 @@ contract RootChain {
     {
         return (childChain[blockNumber].root, childChain[blockNumber].created_at);
     }
-
-    function getExit(uint256 priority)
-        public
-        view
-        returns (address, uint256, uint256)
-    {
-        return (exits[priority].owner, exits[priority].amount, exits[priority].priority);
-    }
 }

--- a/plasma/root_chain/contracts/TestsHelper/TestArrayUtils.sol
+++ b/plasma/root_chain/contracts/TestsHelper/TestArrayUtils.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.4.18;
+import 'ArrayUtils.sol';
+
+contract TestArrayUtils {
+    using ArrayUtils for uint256[];
+
+    function TestArrayUtils() public {
+
+    }
+
+    function testIndexOf() public {
+        uint256[] array;
+        array.push(1);
+        array.push(2);
+        array.push(3);
+        assert(array.indexOf(1) == 0);
+        assert(array.indexOf(2) == 1);
+        assert(array.indexOf(3) == 2);
+    }
+
+    function testRemove() public {
+        uint256[] array;
+        array.push(1);
+        array.push(2);
+        array.push(3);
+        array.remove(1);
+        assert(array.length == 2);
+
+        assert(array.remove(1) == false);
+
+        array.remove(2);
+        assert(array.length == 1);
+        array.remove(3);
+        assert(array.length == 0);
+    }
+}

--- a/tests/root_chain/contracts/libraries/test_array_utils.py
+++ b/tests/root_chain/contracts/libraries/test_array_utils.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture
+def array_utils_helper(get_contract):
+    return get_contract('TestsHelper/TestArrayUtils.sol')
+
+
+def test_index_of(array_utils_helper):
+    array_utils_helper.testIndexOf()
+
+
+def test_remove(array_utils_helper):
+    array_utils_helper.testRemove()


### PR DESCRIPTION
Modify `exitIds` structure from `mapping(uint256 => uint256)` to `mapping(uint256 => uint256[])`.
Each `exitIds[priority]` will have a list of exit IDs. When finalizing exits, we clear all exits with same priority at once.