### PR TITLE
Remove txBytes parameter from deposit function

### DIFF
--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -35,7 +35,7 @@ class Client(object):
         return transaction
 
     def deposit(self, transaction, key):
-        self.root_chain.deposit(rlp.encode(transaction, UnsignedTransaction), transact={'from': '0x' + transaction.newowner1.hex(), 'value': transaction.amount1})
+        self.root_chain.deposit(transact={'from': '0x' + transaction.newowner1.hex(), 'value': transaction.amount1})
 
     def apply_transaction(self, transaction):
         self.child_chain.apply_transaction(transaction)

--- a/plasma/root_chain/contracts/Libraries/ByteUtils.sol
+++ b/plasma/root_chain/contracts/Libraries/ByteUtils.sol
@@ -6,24 +6,43 @@ pragma solidity 0.4.18;
  *
  * @dev Based on https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol
  */
-
 library ByteUtils {
+    // Based on https://ethereum.stackexchange.com/a/40922 with some modification
+    function bytes32ToBytes(bytes32 data) internal pure returns (bytes memory result) {
+        uint i = 0;
+        uint j = 0;
+
+        while (i < 32 && uint(data[i]) == 0) {
+            ++i;
+        }
+
+        result = new bytes(32 - i);
+
+        while (i < 32) {
+            result[j] = data[i];
+            ++i;
+            ++j;
+        }
+
+        return result;
+    }
+
     function slice(bytes _bytes, uint _start, uint _length)
         internal
         pure
         returns (bytes)
     {
-        
+
         bytes memory tempBytes;
-        
+
         assembly {
             tempBytes := mload(0x40)
-            
+
             let lengthmod := and(_length, 31)
-            
+
             let mc := add(tempBytes, lengthmod)
             let end := add(mc, _length)
-            
+
             for {
                 let cc := add(add(_bytes, lengthmod), _start)
             } lt(mc, end) {
@@ -32,14 +51,14 @@ library ByteUtils {
             } {
                 mstore(mc, mload(cc))
             }
-            
+
             mstore(tempBytes, _length)
-            
+
             //update free-memory pointer
             //allocating the array padded to 32 bytes like the compiler does now
             mstore(0x40, and(add(mc, 31), not(31)))
         }
-        
+
         return tempBytes;
     }
 }

--- a/plasma/root_chain/contracts/Libraries/RLP.sol
+++ b/plasma/root_chain/contracts/Libraries/RLP.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.4.18;
+
 /**
 * @title RLPReader
 *
@@ -278,7 +279,7 @@ library RLP {
     function toInt(RLPItem memory self)
         internal
         view
-        returns (int data) 
+        returns (int data)
     {
         return int(toUint(self));
     }
@@ -427,7 +428,7 @@ library RLP {
     // Check that an RLP item is valid.
     function _validate(RLPItem memory self)
         private
-        pure 
+        pure
         returns (bool ret)
     {
         // Check that RLP is well-formed.

--- a/plasma/root_chain/contracts/Libraries/RLPEncode.sol
+++ b/plasma/root_chain/contracts/Libraries/RLPEncode.sol
@@ -1,0 +1,127 @@
+pragma solidity ^0.4.18;
+
+/**
+ * @title RLPEncode
+ *
+ * @dev Based on https://github.com/sammayo/solidity-rlp-encoder/blob/master/RLPEncode.sol
+ */
+
+library RLPEncode {
+    uint8 constant STRING_SHORT_PREFIX = 0x80;
+    uint8 constant STRING_LONG_PREFIX = 0xb7;
+    uint8 constant LIST_SHORT_PREFIX = 0xc0;
+    uint8 constant LIST_LONG_PREFIX = 0xf7;
+
+    /// @dev Rlp encodes a bytes
+    /// @param self The bytes to be encoded
+    /// @return The rlp encoded bytes
+    function encodeBytes(bytes memory self) internal constant returns (bytes) {
+        bytes memory encoded;
+        if (self.length == 1 && uint(self[0]) < 0x80) {
+            encoded = new bytes(1);
+            encoded = self;
+        } else {
+            encoded = encode(self, STRING_SHORT_PREFIX, STRING_LONG_PREFIX);
+        }
+        return encoded;
+    }
+
+    /// @dev Rlp encodes a bytes[]. Note that the items in the bytes[] will not automatically be rlp encoded.
+    /// @param self The bytes[] to be encoded
+    /// @return The rlp encoded bytes[]
+    function encodeList(bytes[] memory self) internal constant returns (bytes) {
+        bytes memory list = flatten(self);
+        bytes memory encoded = encode(list, LIST_SHORT_PREFIX, LIST_LONG_PREFIX);
+        return encoded;
+    }
+
+    function encode(bytes memory self, uint8 prefix1, uint8 prefix2) private constant returns (bytes) {
+        uint selfPtr;
+        assembly { selfPtr := add(self, 0x20) }
+
+        bytes memory encoded;
+        uint encodedPtr;
+
+        uint len = self.length;
+        uint lenLen;
+        uint i = 0x1;
+        while (len/i != 0) {
+            lenLen++;
+            i *= 0x100;
+        }
+
+        if (len <= 55) {
+            encoded = new bytes(len+1);
+
+            // length encoding byte
+            encoded[0] = byte(prefix1+len);
+
+            // string/list contents
+            assembly { encodedPtr := add(encoded, 0x21) }
+            memcpy(encodedPtr, selfPtr, len);
+        } else {
+            // 1 is the length of the length of the length
+            encoded = new bytes(1+lenLen+len);
+
+            // length of the length encoding byte
+            encoded[0] = byte(prefix2+lenLen);
+
+            // length bytes
+            for (i = 1; i <= lenLen; i++) {
+                encoded[i] = byte((len/(0x100**(lenLen-i)))%0x100);
+            }
+
+            // string/list contents
+            assembly { encodedPtr := add(add(encoded, 0x21), lenLen) }
+            memcpy(encodedPtr, selfPtr, len);
+        }
+        return encoded;
+    }
+
+    function flatten(bytes[] memory self) private constant returns (bytes) {
+        if (self.length == 0) {
+            return new bytes(0);
+        }
+
+        uint len;
+        for (uint i = 0; i < self.length; i++) {
+            len += self[i].length;
+        }
+
+        bytes memory flattened = new bytes(len);
+        uint flattenedPtr;
+        assembly { flattenedPtr := add(flattened, 0x20) }
+
+        for (i = 0; i < self.length; i++) {
+            bytes memory item = self[i];
+
+            uint selfPtr;
+            assembly { selfPtr := add(item, 0x20)}
+
+            memcpy(flattenedPtr, selfPtr, item.length);
+            flattenedPtr += self[i].length;
+        }
+
+        return flattened;
+    }
+
+    /// This function is from Nick Johnson's string utils library
+    function memcpy(uint dest, uint src, uint len) private {
+        // Copy word-length chunks while possible
+        for (; len >= 32; len -= 32) {
+            assembly {
+                mstore(dest, mload(src))
+            }
+            dest += 32;
+            src += 32;
+        }
+
+        // Copy remaining bytes
+        uint mask = 256 ** (32 - len) - 1;
+        assembly {
+            let srcpart := and(mload(src), not(mask))
+            let destpart := and(mload(dest), mask)
+            mstore(dest, or(destpart, srcpart))
+        }
+    }
+}

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -21,13 +21,12 @@ def testNextBlockNumber(t, root_chain):
 
 
 def test_deposit(t, root_chain):
-    owner, value_1 = t.a1, 100
+    owner, value_1, key = t.a1, 100, t.k1
     null_address = b'\x00' * 20
     tx = Transaction(0, 0, 0, 0, 0, 0,
                      owner, value_1, null_address, 0, 0)
-    tx_bytes = rlp.encode(tx, UnsignedTransaction)
     blknum = root_chain.getDepositBlock()
-    root_chain.deposit(tx_bytes, value=value_1)
+    root_chain.deposit(value=value_1, sender=key)
     assert root_chain.getChildChain(blknum)[0] == get_merkle_of_leaves(16, [tx.hash + tx.sig1 + tx.sig2]).root
     assert root_chain.getChildChain(blknum)[1] == t.chain.head_state.timestamp
 
@@ -41,7 +40,7 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     tx_bytes1 = rlp.encode(tx1, UnsignedTransaction)
     dep_blknum = root_chain.getDepositBlock()
     assert dep_blknum == 1
-    root_chain.deposit(tx_bytes1, value=value_1)
+    root_chain.deposit(value=value_1, sender=key)
     merkle = FixedMerkle(16, [tx1.merkle_hash], True)
     proof = merkle.create_membership_proof(tx1.merkle_hash)
     confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep_blknum)[0], key)
@@ -79,7 +78,7 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     t.chain.revert(snapshot)
     dep2_blknum = root_chain.getDepositBlock()
     assert dep2_blknum == 1001
-    root_chain.deposit(tx_bytes1, value=value_1)
+    root_chain.deposit(value=value_1, sender=key)
     tx3 = Transaction(child_blknum, 0, 0, dep2_blknum, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx3.sign1(key)
@@ -107,7 +106,7 @@ def test_challenge_exit(t, u, root_chain):
                       owner, value_1, null_address, 0, 0)
     tx_bytes1 = rlp.encode(tx1, UnsignedTransaction)
     dep1_blknum = root_chain.getDepositBlock()
-    root_chain.deposit(tx_bytes1, value=value_1)
+    root_chain.deposit(value=value_1, sender=key)
     merkle = FixedMerkle(16, [tx1.merkle_hash], True)
     proof = merkle.create_membership_proof(tx1.merkle_hash)
     confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep1_blknum)[0], key)
@@ -140,7 +139,7 @@ def test_finalize_exits(t, u, root_chain):
                       owner, value_1, null_address, 0, 0)
     tx_bytes1 = rlp.encode(tx1, UnsignedTransaction)
     dep1_blknum = root_chain.getDepositBlock()
-    root_chain.deposit(tx_bytes1, value=value_1)
+    root_chain.deposit(value=value_1, sender=key)
     merkle = FixedMerkle(16, [tx1.merkle_hash], True)
     proof = merkle.create_membership_proof(tx1.merkle_hash)
     confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep1_blknum)[0], key)


### PR DESCRIPTION
With [RLPEncode library](https://github.com/sammayo/solidity-rlp-encoder/blob/master/RLPEncode.sol), we can make plasma transaction in RootChain contract removing `txBytes` parameter at [deposit()](https://github.com/omisego/plasma-mvp/blob/3094d30e7988e7b0f89ceab35d37f931f01fee6e/plasma/root_chain/contracts/RootChain/RootChain.sol#L128).  


cost type | total gas used
-- | --
transaction cost | 51224 gas
execution cost | 29952 gas

