### PR TITLE
Add implicit fees

### DIFF
--- a/plasma/child_chain/child_chain.py
+++ b/plasma/child_chain/child_chain.py
@@ -54,7 +54,7 @@ class ChildChain(object):
     def validate_tx(self, tx):
         inputs = [(tx.blknum1, tx.txindex1, tx.oindex1), (tx.blknum2, tx.txindex2, tx.oindex2)]
 
-        output_amount = tx.amount1 + tx.amount2 + tx.fee
+        output_amount = tx.amount1 + tx.amount2
         input_amount = 0
 
         for (blknum, txindex, oindex) in inputs:
@@ -77,7 +77,7 @@ class ChildChain(object):
             if not valid_signature:
                 raise InvalidTxSignatureException('failed to validate tx')
 
-        if input_amount != output_amount:
+        if input_amount < output_amount:
             raise TxAmountMismatchException('failed to validate tx')
 
     def mark_utxo_spent(self, blknum, txindex, oindex):

--- a/plasma/child_chain/transaction.py
+++ b/plasma/child_chain/transaction.py
@@ -17,7 +17,6 @@ class Transaction(rlp.Serializable):
         ('amount1', big_endian_int),
         ('newowner2', utils.address),
         ('amount2', big_endian_int),
-        ('fee', big_endian_int),
         ('sig1', binary),
         ('sig2', binary),
     ]
@@ -27,7 +26,6 @@ class Transaction(rlp.Serializable):
                  blknum2, txindex2, oindex2,
                  newowner1, amount1,
                  newowner2, amount2,
-                 fee,
                  sig1=b'\x00' * 65,
                  sig2=b'\x00' * 65):
         # Input 1
@@ -48,9 +46,6 @@ class Transaction(rlp.Serializable):
 
         self.newowner2 = utils.normalize_address(newowner2)
         self.amount2 = amount2
-
-        # Fee
-        self.fee = fee
 
         self.confirmation1 = None
         self.confirmation2 = None

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -118,6 +118,13 @@ contract RootChain {
         addExitToQueue(depositPos, msg.sender, amount);
     }
 
+    function startFeeExit(uint256 amount)
+        public
+        isAuthority
+    {
+        addExitToQueue(0, msg.sender, amount);
+    }
+
     // @dev Starts to exit a specified utxo
     // @param utxoPos The position of the exiting utxo in the format of blknum * 1000000000 + index * 10000 + oindex
     // @param txBytes The transaction being exited in RLP bytes format

--- a/tests/child_chain/test_child_chain.py
+++ b/tests/child_chain/test_child_chain.py
@@ -26,8 +26,8 @@ def child_chain():
     child_chain = ChildChain(AUTHORITY, Mock())
 
     # Create some valid transations
-    tx1 = Transaction(0, 0, 0, 0, 0, 0, newowner1, amount1, b'\x00' * 20, 0, 0)
-    tx2 = Transaction(0, 0, 0, 0, 0, 0, newowner1, amount1, b'\x00' * 20, 0, 0)
+    tx1 = Transaction(0, 0, 0, 0, 0, 0, newowner1, amount1, b'\x00' * 20, 0)
+    tx2 = Transaction(0, 0, 0, 0, 0, 0, newowner1, amount1, b'\x00' * 20, 0)
 
     # Create a block with those transactions
     child_chain.blocks[1] = Block([tx1, tx2])
@@ -36,7 +36,7 @@ def child_chain():
 
 
 def test_send_tx_with_sig(child_chain):
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0)
 
     # Sign the transaction
     tx3.sign1(tx_key)
@@ -46,14 +46,14 @@ def test_send_tx_with_sig(child_chain):
 
 
 def test_send_tx_no_sig(child_chain):
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0)
 
     with pytest.raises(InvalidTxSignatureException):
         child_chain.apply_transaction(rlp.encode(tx3).hex())
 
 
 def test_send_tx_invalid_sig(child_chain):
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0)
 
     # Sign with an invalid key
     tx3.sign1(invalid_tx_key)
@@ -64,7 +64,7 @@ def test_send_tx_invalid_sig(child_chain):
 
 
 def test_send_tx_double_spend(child_chain):
-    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0, 0)
+    tx3 = Transaction(1, 0, 0, 1, 1, 0, newowner1, amount2, b'\x00' * 20, 0)
 
     tx3.sign1(tx_key)
     tx3.sign2(tx_key)
@@ -109,7 +109,7 @@ def test_submit_block_invalid_sig(child_chain):
 def test_submit_block_invalid_tx_set(child_chain):
     block = Block()
     block.transaction_set = child_chain.current_block.transaction_set[:]
-    unsubmitted_tx = Transaction(0, 0, 0, 0, 0, 0, newowner1, 1234, b'\x00' * 20, 0, 0)
+    unsubmitted_tx = Transaction(0, 0, 0, 0, 0, 0, newowner1, 1234, b'\x00' * 20, 0)
     # Add an arbitrary transaction that hasn't been correctly submitted
     block.transaction_set.append(unsubmitted_tx)
 

--- a/tests/child_chain/test_transaction.py
+++ b/tests/child_chain/test_transaction.py
@@ -6,14 +6,12 @@ def test_transaction(t):
     blknum2, txindex2, oindex2 = 2, 2, 1
     newowner1, amount1 = t.a1, 100
     newowner2, amount2 = t.a2, 150
-    fee = 5
     oldowner1, oldowner2 = t.a1, t.a2
     key1, key2 = t.k1, t.k2
     tx = Transaction(blknum1, txindex1, oindex1,
                      blknum2, txindex2, oindex2,
                      newowner1, amount1,
-                     newowner2, amount2,
-                     fee)
+                     newowner2, amount2)
     assert tx.blknum1 == blknum1
     assert tx.txindex1 == txindex1
     assert tx.oindex1 == oindex1

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -44,6 +44,16 @@ def test_start_deposit_exit(t, u, root_chain, assert_tx_failed):
     assert_tx_failed(lambda: root_chain.startDepositExit(utxo_pos, value_1 + 1))
 
 
+def test_start_fee_exit(t, u, root_chain, assert_tx_failed):
+    root_chain.startFeeExit(1);
+    expected_utxo_pos = 0
+    expected_created_at = t.chain.head_state.timestamp - 60 * 60 * 24 * 7
+    utxo_pos, created_at = root_chain.getNextExit()
+    assert utxo_pos == expected_utxo_pos
+    assert created_at == expected_created_at
+    # Fails if transaction sender isn't the authority
+    assert_tx_failed(lambda: root_chain.startFeeExit(1, sender=t.k1))
+
 def test_start_exit(t, root_chain, assert_tx_failed):
     week_and_a_half = 60 * 60 * 24 * 13
     owner, value_1, key = t.a1, 100, t.k1

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -45,21 +45,34 @@ def test_start_deposit_exit(t, u, root_chain, assert_tx_failed):
 
 
 def test_start_fee_exit(t, u, root_chain, assert_tx_failed):
-    root_chain.startFeeExit(1);
-    expected_utxo_pos = 0
-    expected_created_at = t.chain.head_state.timestamp - 60 * 60 * 24 * 7
+    value_1 = 100
+    blknum = root_chain.getDepositBlock()
+    root_chain.deposit(value=value_1)
+    expected_utxo_pos = root_chain.currentFeeExit()
+    expected_created_at = t.chain.head_state.timestamp + 1
+    assert root_chain.currentFeeExit() == 1
+    root_chain.startFeeExit(1)
+    assert root_chain.currentFeeExit() == 2
     utxo_pos, created_at = root_chain.getNextExit()
+    fee_priority = created_at << 128 | utxo_pos
     assert utxo_pos == expected_utxo_pos
     assert created_at == expected_created_at
+
+    expected_utxo_pos = blknum * 1000000000 + 1
+    root_chain.startDepositExit(expected_utxo_pos, value_1)
+    utxo_pos, created_at = root_chain.getNextExit()
+    deposit_priority = created_at << 128 | utxo_pos
+    assert fee_priority > deposit_priority
     # Fails if transaction sender isn't the authority
     assert_tx_failed(lambda: root_chain.startFeeExit(1, sender=t.k1))
+
 
 def test_start_exit(t, root_chain, assert_tx_failed):
     week_and_a_half = 60 * 60 * 24 * 13
     owner, value_1, key = t.a1, 100, t.k1
     null_address = b'\x00' * 20
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
-                      owner, value_1, null_address, 0, 0)
+                      owner, value_1, null_address, 0)
     deposit_tx_hash = get_deposit_hash(owner, value_1)
     dep_blknum = root_chain.getDepositBlock()
     assert dep_blknum == 1
@@ -82,7 +95,7 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     t.chain.revert(snapshot)
 
     tx2 = Transaction(dep_blknum, 0, 0, 0, 0, 0,
-                      owner, value_1, null_address, 0, 0)
+                      owner, value_1, null_address, 0)
     tx2.sign1(key)
     tx_bytes2 = rlp.encode(tx2, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx2.merkle_hash], True)
@@ -126,7 +139,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     owner, value_1, key = t.a1, 100, t.k1
     null_address = b'\x00' * 20
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
-                      owner, value_1, null_address, 0, 0)
+                      owner, value_1, null_address, 0)
     deposit_tx_hash = get_deposit_hash(owner, value_1)
     utxo_pos1 = root_chain.getDepositBlock() * 1000000000 + 1
     root_chain.deposit(value=value_1, sender=key)
@@ -138,7 +151,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
     root_chain.startDepositExit(utxo_pos1, tx1.amount1, sender=key)
     tx3 = Transaction(utxo_pos2, 0, 0, 0, 0, 0,
-                      owner, value_1, null_address, 0, 0)
+                      owner, value_1, null_address, 0)
     tx3.sign1(key)
     tx_bytes3 = rlp.encode(tx3, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx3.merkle_hash], True)
@@ -149,7 +162,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     sigs = tx3.sig1 + tx3.sig2
     utxo_pos3 = child_blknum * 1000000000 + 10000 * 0 + 0
     tx4 = Transaction(utxo_pos1, 0, 0, 0, 0, 0,
-                      owner, value_1, null_address, 0, 0)
+                      owner, value_1, null_address, 0)
     tx4.sign1(key)
     tx_bytes4 = rlp.encode(tx4, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx4.merkle_hash], True)
@@ -176,7 +189,7 @@ def test_finalize_exits(t, u, root_chain):
     owner, value_1, key = t.a1, 100, t.k1
     null_address = b'\x00' * 20
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
-                      owner, value_1, null_address, 0, 0)
+                      owner, value_1, null_address, 0)
     dep1_blknum = root_chain.getDepositBlock()
     root_chain.deposit(value=value_1, sender=key)
     utxo_pos1 = dep1_blknum * 1000000000 + 10000 * 0 + 1


### PR DESCRIPTION
Changes child chain transaction fees from being explicit to implicit reducing transaction size and computation required by child chain while slightly increasing the amount of information users have to track.

The operator can now exit any amount using `startFeeExit` and it's up to the users of the chain to verify that the operator is not withdrawing more fees than they're due and exit if they are.