### PR TITLE
Fix depositing from CLI

### DIFF
--- a/plasma/cli/client.py
+++ b/plasma/cli/client.py
@@ -63,7 +63,7 @@ class ClientParser():
                          newOwner1, amount1,
                          newOwner2, amount2,
                          0)
-        self.client.deposit(tx, key)
+        self.client.deposit(tx)
         print("Succesfully deposited %s to %s" % (amount1, newOwner1))
 
     def send_tx(self):

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -35,7 +35,7 @@ class Client(object):
         return transaction
 
     def deposit(self, transaction):
-        self.root_chain.deposit(rlp.encode(transaction, UnsignedTransaction), transact={'from': '0x' + transaction.newowner1.hex(), 'value': transaction.amount1})
+        self.root_chain.deposit(transact={'from': '0x' + transaction.newowner1.hex(), 'value': transaction.amount1})
 
     def apply_transaction(self, transaction):
         self.child_chain.apply_transaction(transaction)


### PR DESCRIPTION
from [this commit](https://github.com/omisego/plasma-mvp/commit/c48d1ad0f0ed6965e3f4338229764e4cb260090b#diff-15bc2db6ab0db1defb51e696d2d98378), the command `deposit` does not work with the error like `TypeError: deposit() takes 2 positional arguments but 3 were given`

this is because the arguments of `deposit` func on `client/client.py` has been changed on this commit

And also the `deposit` func on `client/client.py` does not work since the root chain function has been changed ref: https://github.com/omisego/plasma-mvp/issues/89#issue-312294240
