### PR TITLE
Fixes Issue #66 - Transfer DoS 2nd Proposal

### DIFF
--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -175,6 +175,8 @@ def test_finalize_exits(t, u, root_chain):
     assert root_chain.exits(utxo_pos1) == ['0x' + owner.hex(), 100]
     pre_balance = t.chain.head_state.get_balance(owner)
     root_chain.finalizeExits(sender=t.k2)
+    assert root_chain.balances(owner) == value_1
+    root_chain.withdraw(sender=key)
     post_balance = t.chain.head_state.get_balance(owner)
     assert post_balance == pre_balance + value_1
     assert root_chain.exits(utxo_pos1) == ['0x0000000000000000000000000000000000000000', value_1]


### PR DESCRIPTION
This PR solves the issue #66.

It proposes to prevent a possible DoS withdraw attack, where an attacker prevents everybody to withdraw any funds from the root-contract by making this withdraw request throw all the time.

This is prevented by avoiding the transfer function during the finalizeExit call and only crediting balances, which can be withdrawn later.
In order to prevent any race on the withdraw requests of the balance, it is ensured that never more balances are credited, as there are funds in the contract available. 

For this, I calculate the virtualBalance = sum of all deposits - sum of all withdraw request went through finalizeExit.
If virtualBalance < 0, then the chain operator was malicious and in this case stop the finalizeExit method.

While the proposed switch of transfer to send would also work for Ether, I prefer my solution, as it would also work for generic ERC20 Tokens.