### PR TITLE
Fix priority queue and add tests

### DIFF
--- a/plasma/root_chain/contracts/DataStructures/PriorityQueue.sol
+++ b/plasma/root_chain/contracts/DataStructures/PriorityQueue.sol
@@ -76,6 +76,7 @@ contract PriorityQueue {
         delete heapList[currentSize];
         currentSize = currentSize.sub(1);
         percDown(1);
+        heapList.length = heapList.length.sub(1);
         return retVal;
     }
 

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -194,12 +194,17 @@ contract RootChain {
         uint256 created_at;
         (utxoPos, created_at) = getNextExit();
         exit memory currentExit = exits[utxoPos];
-        while (created_at < twoWeekOldTimestamp && exitsQueue.currentSize() > 0) {
+        while (created_at < twoWeekOldTimestamp) {
             currentExit = exits[utxoPos];
             currentExit.owner.transfer(currentExit.amount);
             exitsQueue.delMin();
             delete exits[utxoPos].owner;
-            (utxoPos, created_at) = getNextExit();
+
+            if (exitsQueue.currentSize() > 0) {
+                (utxoPos, created_at) = getNextExit();
+            } else {
+                return;
+            }
         }
     }
 

--- a/tests/root_chain/contracts/data_structures/test_priority_queue.py
+++ b/tests/root_chain/contracts/data_structures/test_priority_queue.py
@@ -7,6 +7,11 @@ def priority_queue(get_contract):
     return get_contract('DataStructures/PriorityQueue.sol')
 
 
+def test_priority_queue_get_min_empty_should_fail(priority_queue):
+    with pytest.raises(TransactionFailed):
+        priority_queue.getMin()
+
+
 def test_priority_queue_insert(priority_queue):
     priority_queue.insert(2)
     assert priority_queue.getMin() == 2
@@ -38,9 +43,6 @@ def test_priority_queue_delete_all(priority_queue):
     assert priority_queue.delMin() == 2
     assert priority_queue.delMin() == 5
     assert priority_queue.currentSize() == 0
-
-    with pytest.raises(TransactionFailed):
-        priority_queue.getMin()
 
 
 def test_priority_queue_delete_then_insert(priority_queue):

--- a/tests/root_chain/contracts/data_structures/test_priority_queue.py
+++ b/tests/root_chain/contracts/data_structures/test_priority_queue.py
@@ -1,4 +1,5 @@
 import pytest
+from ethereum.tools.tester import TransactionFailed
 
 
 @pytest.fixture
@@ -6,15 +7,44 @@ def priority_queue(get_contract):
     return get_contract('DataStructures/PriorityQueue.sol')
 
 
-def test_priority_queue(t, priority_queue):
+def test_priority_queue_insert(priority_queue):
+    priority_queue.insert(2)
+    assert priority_queue.getMin() == 2
+    assert priority_queue.currentSize() == 1
+
+
+def test_priority_queue_insert_multiple(priority_queue):
     priority_queue.insert(2)
     priority_queue.insert(5)
-    priority_queue.insert(3)
     assert priority_queue.getMin() == 2
-    priority_queue.insert(1)
-    assert priority_queue.getMin() == 1
-    assert priority_queue.delMin() == 1
+    assert priority_queue.currentSize() == 2
+
+
+def test_priority_queue_insert_out_of_order(priority_queue):
+    priority_queue.insert(5)
+    priority_queue.insert(2)
+    assert priority_queue.getMin() == 2
+
+
+def test_priority_queue_delete_min(priority_queue):
+    priority_queue.insert(2)
     assert priority_queue.delMin() == 2
-    assert priority_queue.getMin() == 3
-    assert priority_queue.delMin() == 3
+    assert priority_queue.currentSize() == 0
+
+
+def test_priority_queue_delete_all(priority_queue):
+    priority_queue.insert(5)
+    priority_queue.insert(2)
+    assert priority_queue.delMin() == 2
     assert priority_queue.delMin() == 5
+    assert priority_queue.currentSize() == 0
+
+    with pytest.raises(TransactionFailed):
+        priority_queue.getMin()
+
+
+def test_priority_queue_delete_then_insert(priority_queue):
+    priority_queue.insert(2)
+    assert priority_queue.delMin() == 2
+    priority_queue.insert(5)
+    assert priority_queue.getMin() == 5


### PR DESCRIPTION
Fixes #103 and adds/refactors tests so this doesn't happen again. Implements the suggestions by @laskdaf. 

`PriorityQueue.getMin()` when the set is empty now throws. I think this is the most sensible behavior because we can't return a null value to represent that the set is empty. As a result, we no longer need to check that `exitsQueue.currentSize() > 0` in the while loop condition, but do need to do so before reassigning `(utxoPos, created_at)` or risk throwing within the loop. 

Tests pass.