### PR TITLE
Revamp deployer and tests

### DIFF
--- a/deployment.py
+++ b/deployment.py
@@ -1,3 +1,5 @@
 from plasma.root_chain.deployer import Deployer
 
-Deployer().create_contract("RootChain/RootChain.sol")
+deployer = Deployer()
+deployer.compile_all()
+deployer.deploy_contract("RootChain")

--- a/plasma/child_chain/server.py
+++ b/plasma/child_chain/server.py
@@ -5,8 +5,8 @@ from plasma.child_chain.child_chain import ChildChain
 from plasma.config import plasma_config
 from plasma.root_chain.deployer import Deployer
 
-
-child_chain = ChildChain(plasma_config['AUTHORITY'], Deployer().get_contract("RootChain/RootChain.sol"))
+root_chain = Deployer().get_contract_at_address("RootChain", plasma_config['ROOT_CHAIN_CONTRACT_ADDRESS'], concise=False)
+child_chain = ChildChain(plasma_config['AUTHORITY'], root_chain)
 
 
 @Request.application

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -12,8 +12,7 @@ class Client(object):
 
     def __init__(self, root_chain_provider=HTTPProvider('http://localhost:8545'), child_chain_url="http://localhost:8546/jsonrpc"):
         deployer = Deployer(root_chain_provider)
-        abi = json.load(open("contract_data/RootChain.json"))
-        self.root_chain = deployer.w3.eth.contract(abi, plasma_config['ROOT_CHAIN_CONTRACT_ADDRESS'], ContractFactoryClass=ConciseContract)
+        self.root_chain = deployer.get_contract_at_address("RootChain", plasma_config['ROOT_CHAIN_CONTRACT_ADDRESS'], concise=True)
         self.child_chain = ChildChainService(child_chain_url)
 
     def create_transaction(self, blknum1=0, txindex1=0, oindex1=0,

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -1,6 +1,4 @@
-import json
 import rlp
-from web3.contract import ConciseContract
 from web3 import HTTPProvider
 from plasma.config import plasma_config
 from plasma.root_chain.deployer import Deployer

--- a/plasma/root_chain/deployer.py
+++ b/plasma/root_chain/deployer.py
@@ -1,10 +1,8 @@
 import json
 import os
-from ethereum.tools import tester as t
 from solc import compile_standard
 from web3.contract import ConciseContract, Contract
 from web3 import Web3, HTTPProvider
-from plasma.config import plasma_config
 
 OWN_DIR = os.path.dirname(os.path.realpath(__file__))
 CONTRACTS_DIR = OWN_DIR + '/contracts'
@@ -83,7 +81,6 @@ class Deployer(object):
         bytecode = contract_data['evm']['bytecode']['object']
 
         return abi, bytecode
-
 
     def deploy_contract(self, contract_name, gas=5000000, args=(), concise=True):
         """Deploys a contract to the given Ethereum network using Web3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,10 @@ import os
 
 OWN_DIR = os.path.dirname(os.path.realpath(__file__))
 
+# Compile contracts once before tests start
+deployer = Deployer()
+deployer.compile_all()
+
 
 @pytest.fixture
 def t():
@@ -49,7 +53,7 @@ def u():
 @pytest.fixture
 def get_contract(t, u):
     def create_contract(path, args=(), sender=t.k0):
-        abi, hexcode, _ = Deployer().compile_contract(path, args)
+        abi, hexcode = deployer.get_contract_data(path)
         bytecode = u.decode_hex(hexcode)
         ct = ContractTranslator(abi)
         code = bytecode + (ct.encode_constructor_arguments(args) if args else b'')

--- a/tests/root_chain/contracts/data_structures/test_priority_queue.py
+++ b/tests/root_chain/contracts/data_structures/test_priority_queue.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture
 def priority_queue(get_contract):
-    return get_contract('DataStructures/PriorityQueue.sol')
+    return get_contract('PriorityQueue')
 
 
 def test_priority_queue(t, priority_queue):

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -7,7 +7,7 @@ from plasma.utils.utils import confirm_tx, get_deposit_hash
 
 @pytest.fixture
 def root_chain(t, get_contract):
-    contract = get_contract('RootChain/RootChain.sol')
+    contract = get_contract('RootChain')
     t.chain.mine()
     return contract
 


### PR DESCRIPTION
Closes #104 

Revamps the deployer in general and adds some docstrings. Tests now compile all contracts once at the start of testing instead of compiling repeatedly. Saves a few seconds off total test time. 