### PR TITLE
Optimize child chain block submission on root chain smart contract

### DIFF
--- a/plasma/root_chain/contracts/Libraries/Validate.sol
+++ b/plasma/root_chain/contracts/Libraries/Validate.sol
@@ -9,7 +9,7 @@ import "./ECRecovery.sol";
  */
 
 library Validate {
-    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 blknum1, uint256 blknum2, bytes sigs)
+    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 inputCount, bytes sigs)
         internal
         view
         returns (bool)
@@ -24,7 +24,7 @@ library Validate {
         bool check2 = true;
 
         check1 = ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
-        if (blknum2 > 0) {
+        if (inputCount > 0) {
             bytes memory confSig2 = ByteUtils.slice(sigs, 195, 65);
             check2 = ECRecovery.recover(txHash, sig2) == ECRecovery.recover(confirmationHash, confSig2);
         }

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -48,11 +48,6 @@ contract RootChain {
         uint256 amount;
     }
 
-    // struct childBlock {
-    //     bytes32 root;
-    //     uint256 created_at;
-    // }
-
     /*
      *  Modifiers
      */

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -29,7 +29,7 @@ contract RootChain {
     /*
      *  Storage
      */
-    mapping(uint256 => childBlock) public childChain;
+    mapping(uint256 => bytes32) public childChain;
     mapping(uint256 => exit) public exits;
     PriorityQueue exitsQueue;
     address public authority;
@@ -48,10 +48,10 @@ contract RootChain {
         uint256 amount;
     }
 
-    struct childBlock {
-        bytes32 root;
-        uint256 created_at;
-    }
+    // struct childBlock {
+    //     bytes32 root;
+    //     uint256 created_at;
+    // }
 
     /*
      *  Modifiers
@@ -81,10 +81,7 @@ contract RootChain {
         public
         isAuthority
     {
-        childChain[currentChildBlock] = childBlock({
-            root: root,
-            created_at: block.timestamp
-        });
+        childChain[currentChildBlock] = keccak256(root, block.timestamp);
         currentChildBlock = currentChildBlock.add(childBlockInterval);
         currentDepositBlock = 1;
     }
@@ -96,26 +93,24 @@ contract RootChain {
         payable
     {
         require(currentDepositBlock < childBlockInterval);
-        bytes32 root = keccak256(msg.sender, msg.value);
+        bytes32 depositHash = keccak256(msg.sender, msg.value);
         uint256 depositBlock = getDepositBlock();
-        childChain[depositBlock] = childBlock({
-            root: root,
-            created_at: block.timestamp
-        });
+        childChain[depositBlock] = keccak256(depositHash, block.timestamp);
         currentDepositBlock = currentDepositBlock.add(1);
         Deposit(msg.sender, msg.value, depositBlock);
     }
 
-    function startDepositExit(uint256 depositPos, uint256 amount)
+    function startDepositExit(uint256 depositPos, uint256 amount, uint256 createdAt)
         public
     {
         uint256 blknum = depositPos / 1000000000;
         // Makes sure that deposit position is actually a deposit
         require(blknum % childBlockInterval != 0);
-        bytes32 root = childChain[blknum].root;
+        bytes32 root = childChain[blknum];
         bytes32 depositHash = keccak256(msg.sender, amount);
-        require(root == depositHash);
-        addExitToQueue(depositPos, msg.sender, amount);
+        bytes32 depositRoot = keccak256(depositHash, createdAt);
+        require(root == depositRoot);
+        addExitToQueue(depositPos, msg.sender, amount, createdAt);
     }
 
     // @dev Starts to exit a specified utxo
@@ -123,7 +118,7 @@ contract RootChain {
     // @param txBytes The transaction being exited in RLP bytes format
     // @param proof Proof of the exiting transactions inclusion for the block specified by utxoPos
     // @param sigs Both transaction signatures and confirmations signatures used to verify that the exiting transaction has been confirmed
-    function startExit(uint256 utxoPos, bytes txBytes, bytes proof, bytes sigs)
+    function startExit(uint256 utxoPos, bytes txBytes, bytes proof, bytes sigs, bytes32 blockRoot, uint256 createdAt)
         public
     {
         var txList = txBytes.toRLPItem().toList(11); 
@@ -134,19 +129,20 @@ contract RootChain {
         address exitor = txList[6 + 2 * oindex].toAddress(); 
         
         require(msg.sender == exitor);
-        bytes32 root = childChain[blknum].root; 
+        bytes32 root = childChain[blknum];
+        require(root == keccak256(blockRoot, createdAt));
         bytes32 merkleHash = keccak256(keccak256(txBytes), ByteUtils.slice(sigs, 0, 130));
-        require(Validate.checkSigs(keccak256(txBytes), root, txList[0].toUint(), txList[3].toUint(), sigs));
-        require(merkleHash.checkMembership(txindex, root, proof));
-        addExitToQueue(utxoPos, exitor, amount);
+        require(Validate.checkSigs(keccak256(txBytes), blockRoot, txList[0].toUint(), txList[3].toUint(), sigs));
+        require(merkleHash.checkMembership(txindex, blockRoot, proof));
+        addExitToQueue(utxoPos, exitor, amount, createdAt);
     }
 
     // Priority is a given utxos position in the exit priority queue
-    function addExitToQueue(uint256 utxoPos, address exitor, uint256 amount)
+    function addExitToQueue(uint256 utxoPos, address exitor, uint256 amount, uint256 created_at)
         private
     {
         uint256 blknum = utxoPos / 1000000000;
-        uint256 priority = Math.max(childChain[blknum].created_at, block.timestamp - 1 weeks);
+        uint256 priority = Math.max(created_at, block.timestamp - 1 weeks);
         priority = priority << 128 | utxoPos;
         require(amount > 0);
         require(exits[utxoPos].amount == 0);
@@ -165,19 +161,19 @@ contract RootChain {
     // @param proof Proof of inclusion for the transaction used to challenge
     // @param sigs Signatures for the transaction used to challenge
     // @param confirmationSig The confirmation signature for the transaction used to challenge
-    function challengeExit(uint256 cUtxoPos, uint256 eUtxoIndex, bytes txBytes, bytes proof, bytes sigs, bytes confirmationSig)
+    function challengeExit(uint256 cUtxoPos, uint256 eUtxoIndex, bytes txBytes, bytes proof, bytes sigs, bytes confirmationSig, bytes32 blockRoot, uint256 createdAt)
         public
     {
         uint256 eUtxoPos = getUtxoPos(txBytes, eUtxoIndex);
         uint256 txindex = (cUtxoPos % 1000000000) / 10000;
-        bytes32 root = childChain[cUtxoPos / 1000000000].root;
+        require(checkRoot(cUtxoPos / 1000000000, blockRoot, createdAt));
         var txHash = keccak256(txBytes);
-        var confirmationHash = keccak256(txHash, root);
+        var confirmationHash = keccak256(txHash, blockRoot);
         var merkleHash = keccak256(txHash, sigs);
         address owner = exits[eUtxoPos].owner;
 
         require(owner == ECRecovery.recover(confirmationHash, confirmationSig));
-        require(merkleHash.checkMembership(txindex, root, proof));
+        require(merkleHash.checkMembership(txindex, blockRoot, proof));
         // Clear as much as possible from succesful challenge
         delete exits[eUtxoPos].owner;
     }
@@ -204,14 +200,14 @@ contract RootChain {
     /* 
      *  Constant functions
      */
-    function getChildChain(uint256 blockNumber)
-        public
+    function checkRoot(uint256 blknum, bytes32 blockRoot, uint256 createdAt)
+        private
         view
-        returns (bytes32, uint256)
+        returns (bool)
     {
-        return (childChain[blockNumber].root, childChain[blockNumber].created_at);
+        return (childChain[blknum] == keccak256(blockRoot, createdAt));
     }
-
+    
     function getDepositBlock()
         public
         view

--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -101,10 +101,8 @@ contract RootChain {
         uint256 blknum = depositPos / 1000000000;
         // Makes sure that deposit position is actually a deposit
         require(blknum % childBlockInterval != 0);
-        bytes32 root = childChain[blknum];
         bytes32 depositHash = keccak256(msg.sender, amount);
-        bytes32 depositRoot = keccak256(depositHash, createdAt);
-        require(root == depositRoot);
+        require(checkRoot(blknum, depositHash, createdAt));
         addExitToQueue(depositPos, msg.sender, amount, createdAt);
     }
 
@@ -124,10 +122,9 @@ contract RootChain {
         address exitor = txList[6 + 2 * oindex].toAddress(); 
         
         require(msg.sender == exitor);
-        bytes32 root = childChain[blknum];
-        require(root == keccak256(blockRoot, createdAt));
+        require(checkRoot(blknum, blockRoot, createdAt));
         bytes32 merkleHash = keccak256(keccak256(txBytes), ByteUtils.slice(sigs, 0, 130));
-        require(Validate.checkSigs(keccak256(txBytes), blockRoot, txList[0].toUint(), txList[3].toUint(), sigs));
+        require(Validate.checkSigs(keccak256(txBytes), blockRoot, txList[3].toUint(), sigs));
         require(merkleHash.checkMembership(txindex, blockRoot, proof));
         addExitToQueue(utxoPos, exitor, amount, createdAt);
     }

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -153,7 +153,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     root = merkle.root
     child_blknum = root_chain.currentChildBlock()
     root_chain.submitBlock(root)
-    confirmSig = confirm_tx(tx4, merkle.root, key)
+    confirmSig = confirm_tx(tx4, root, key)
     sigs = tx4.sig1 + tx4.sig2
     utxo_pos4 = child_blknum * 1000000000 + 10000 * 0 + 0
     oindex1 = 0

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -14,22 +14,24 @@ def root_chain(t, get_contract):
 
 def test_deposit(t, u, root_chain):
     owner, value_1 = t.a0, 100
+    depositHash = u.sha3(owner + b'\x00' * 31 + u.int_to_bytes(value_1))
+    root = u.sha3(depositHash + b'\x00' * 28 + u.int_to_bytes(t.chain.head_state.timestamp))
     blknum = root_chain.getDepositBlock()
     root_chain.deposit(value=value_1)
-    assert root_chain.getChildChain(blknum)[0] == u.sha3(owner + b'\x00' * 31 + u.int_to_bytes(value_1))
-    assert root_chain.getChildChain(blknum)[1] == t.chain.head_state.timestamp
+    assert root_chain.childChain(blknum) == root
     assert root_chain.getDepositBlock() == blknum + 1
 
 
 def test_start_deposit_exit(t, u, root_chain, assert_tx_failed):
     value_1 = 100
+    created_at = t.chain.head_state.timestamp
     # Deposit once to make sure everything works for deposit block
     root_chain.deposit(value=value_1)
     blknum = root_chain.getDepositBlock()
     root_chain.deposit(value=value_1)
     expected_utxo_pos = blknum * 1000000000
     expected_created_at = t.chain.head_state.timestamp
-    root_chain.startDepositExit(expected_utxo_pos, value_1)
+    root_chain.startDepositExit(expected_utxo_pos, value_1, created_at)
     utxo_pos, created_at = root_chain.getNextExit()
     assert utxo_pos == expected_utxo_pos
     assert created_at == expected_created_at
@@ -47,6 +49,7 @@ def test_start_deposit_exit(t, u, root_chain, assert_tx_failed):
 def test_start_exit(t, root_chain, assert_tx_failed):
     week_and_a_half = 60 * 60 * 24 * 13
     owner, value_1, key = t.a1, 100, t.k1
+    created_at = t.chain.head_state.timestamp
     null_address = b'\x00' * 20
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
@@ -56,13 +59,13 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     root_chain.deposit(value=value_1, sender=key)
     merkle = FixedMerkle(16, [deposit_tx_hash], True)
     proof = merkle.create_membership_proof(deposit_tx_hash)
-    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(dep_blknum)[0], key)
+    confirmSig1 = confirm_tx(tx1, merkle.root, key)
     priority1 = dep_blknum * 1000000000 + 10000 * 0 + 1
     snapshot = t.chain.snapshot()
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
     utxoId = dep_blknum * 1000000000 + 10000 * 0 + 1
     # Deposit exit
-    root_chain.startDepositExit(utxoId, tx1.amount1, sender=key)
+    root_chain.startDepositExit(utxoId, tx1.amount1, created_at, sender=key)
 
     t.chain.head_state.timestamp += week_and_a_half
     # Cannot exit twice off of the same utxo
@@ -77,16 +80,17 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     tx_bytes2 = rlp.encode(tx2, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx2.merkle_hash], True)
     proof = merkle.create_membership_proof(tx2.merkle_hash)
+    root = merkle.root
     child_blknum = root_chain.currentChildBlock()
     assert child_blknum == 1000
     root_chain.submitBlock(merkle.root)
-    confirmSig1 = confirm_tx(tx2, root_chain.getChildChain(child_blknum)[0], key)
+    confirmSig1 = confirm_tx(tx2, merkle.root, key)
     priority2 = child_blknum * 1000000000 + 10000 * 0 + 0
     sigs = tx2.sig1 + tx2.sig2 + confirmSig1
     snapshot = t.chain.snapshot()
     # # Single input exit
     utxo_pos2 = child_blknum * 1000000000 + 10000 * 0 + 0
-    root_chain.startExit(utxo_pos2, tx_bytes2, proof, sigs, sender=key)
+    root_chain.startExit(utxo_pos2, tx_bytes2, proof, sigs, root, created_at, sender=key)
     assert root_chain.getExit(priority2) == ['0x' + owner.hex(), 100]
     t.chain.revert(snapshot)
     dep2_blknum = root_chain.getDepositBlock()
@@ -99,21 +103,23 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     tx_bytes3 = rlp.encode(tx3, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx3.merkle_hash], True)
     proof = merkle.create_membership_proof(tx3.merkle_hash)
+    root = merkle.root
     child2_blknum = root_chain.currentChildBlock()
     assert child2_blknum == 2000
     root_chain.submitBlock(merkle.root)
-    confirmSig1 = confirm_tx(tx3, root_chain.getChildChain(child2_blknum)[0], key)
-    confirmSig2 = confirm_tx(tx3, root_chain.getChildChain(child2_blknum)[0], key)
+    confirmSig1 = confirm_tx(tx3, merkle.root, key)
+    confirmSig2 = confirm_tx(tx3, merkle.root, key)
     priority3 = child2_blknum * 1000000000 + 10000 * 0 + 0
     sigs = tx3.sig1 + tx3.sig2 + confirmSig1 + confirmSig2
     # Double input exit
     utxoPos3 = child2_blknum * 1000000000 + 10000 * 0 + 0
-    root_chain.startExit(utxoPos3, tx_bytes3, proof, sigs, sender=key)
+    root_chain.startExit(utxoPos3, tx_bytes3, proof, sigs, root, created_at, sender=key)
     assert root_chain.getExit(priority3) == ['0x' + owner.hex(), 100]
 
 
 def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     owner, value_1, key = t.a1, 100, t.k1
+    created_at = t.chain.head_state.timestamp
     null_address = b'\x00' * 20
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
@@ -124,9 +130,9 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     root_chain.deposit(value=value_1, sender=key)
     merkle = FixedMerkle(16, [deposit_tx_hash], True)
     proof = merkle.create_membership_proof(deposit_tx_hash)
-    confirmSig1 = confirm_tx(tx1, root_chain.getChildChain(utxo_pos1)[0], key)
+    confirmSig1 = confirm_tx(tx1, merkle.root, key)
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
-    root_chain.startDepositExit(utxo_pos1, tx1.amount1, sender=key)
+    root_chain.startDepositExit(utxo_pos1, tx1.amount1, created_at, sender=key)
     tx3 = Transaction(utxo_pos2, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     tx3.sign1(key)
@@ -135,7 +141,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     proof = merkle.create_membership_proof(tx3.merkle_hash)
     child_blknum = root_chain.currentChildBlock()
     root_chain.submitBlock(merkle.root)
-    confirmSig = confirm_tx(tx3, root_chain.getChildChain(child_blknum)[0], key)
+    confirmSig = confirm_tx(tx3, merkle.root, key)
     sigs = tx3.sig1 + tx3.sig2
     utxo_pos3 = child_blknum * 1000000000 + 10000 * 0 + 0
     tx4 = Transaction(utxo_pos1, 0, 0, 0, 0, 0,
@@ -144,9 +150,10 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     tx_bytes4 = rlp.encode(tx4, UnsignedTransaction)
     merkle = FixedMerkle(16, [tx4.merkle_hash], True)
     proof = merkle.create_membership_proof(tx4.merkle_hash)
+    root = merkle.root
     child_blknum = root_chain.currentChildBlock()
-    root_chain.submitBlock(merkle.root)
-    confirmSig = confirm_tx(tx4, root_chain.getChildChain(child_blknum)[0], key)
+    root_chain.submitBlock(root)
+    confirmSig = confirm_tx(tx4, merkle.root, key)
     sigs = tx4.sig1 + tx4.sig2
     utxo_pos4 = child_blknum * 1000000000 + 10000 * 0 + 0
     oindex1 = 0
@@ -157,20 +164,21 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos4, utxo_pos1, tx_bytes4, proof[::-1], sigs, confirmSig))
     # Fails if transaction confirmation is incorrect
     assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos4, utxo_pos1, tx_bytes4, proof, sigs, confirmSig[::-1]))
-    root_chain.challengeExit(utxo_pos4, oindex1, tx_bytes4, proof, sigs, confirmSig)
+    root_chain.challengeExit(utxo_pos4, oindex1, tx_bytes4, proof, sigs, confirmSig, root, created_at)
     assert root_chain.exits(utxo_pos1) == ['0x0000000000000000000000000000000000000000', value_1]
 
 
 def test_finalize_exits(t, u, root_chain):
     two_weeks = 60 * 60 * 24 * 14
     owner, value_1, key = t.a1, 100, t.k1
+    created_at = t.chain.head_state.timestamp
     null_address = b'\x00' * 20
     tx1 = Transaction(0, 0, 0, 0, 0, 0,
                       owner, value_1, null_address, 0, 0)
     dep1_blknum = root_chain.getDepositBlock()
     root_chain.deposit(value=value_1, sender=key)
     utxo_pos1 = dep1_blknum * 1000000000 + 10000 * 0 + 1
-    root_chain.startDepositExit(utxo_pos1, tx1.amount1, sender=key)
+    root_chain.startDepositExit(utxo_pos1, tx1.amount1, created_at, sender=key)
     t.chain.head_state.timestamp += two_weeks * 2
     assert root_chain.exits(utxo_pos1) == ['0x' + owner.hex(), 100]
     pre_balance = t.chain.head_state.get_balance(owner)


### PR DESCRIPTION
Reduces storage used by child chain block submission from 64 bytes to 32 bytes. @kfichter 