### PR TITLE
client decodes blocks before returning them

### DIFF
--- a/plasma/cli/cli.py
+++ b/plasma/cli/cli.py
@@ -1,9 +1,7 @@
 import click
-import rlp
 from ethereum import utils
 from plasma.utils.utils import confirm_tx
 from plasma.client.client import Client
-from plasma.child_chain.block import Block
 from plasma.child_chain.transaction import Transaction
 
 
@@ -76,9 +74,8 @@ def sendtx(client,
 @click.argument('key', required=True)
 @click.pass_obj
 def submitblock(client, key):
-    # Get the current block and decode it
-    encoded_block = client.get_current_block()
-    block = rlp.decode(utils.decode_hex(encoded_block), Block)
+    # Get the current block, already decoded by client
+    block = client.get_current_block()
 
     # Sign the block
     block.make_mutable()
@@ -99,9 +96,8 @@ def submitblock(client, key):
 def withdraw(client,
              blknum, txindex, oindex,
              key1, key2):
-    # Get the transaction's block and decode it
-    encoded_block = client.get_block(blknum)
-    block = rlp.decode(utils.decode_hex(encoded_block), Block)
+    # Get the transaction's block, already decoded by client
+    block = client.get_block(blknum)
 
     # Create a Merkle proof
     tx = block.transaction_set[txindex]

--- a/plasma/client/child_chain_service.py
+++ b/plasma/client/child_chain_service.py
@@ -1,5 +1,8 @@
 import requests
+import rlp
 from plasma.child_chain.child_chain import ChildChain
+from plasma.child_chain.transaction import Transaction
+from plasma.child_chain.block import Block
 
 
 class ChildChainService(object):
@@ -19,10 +22,10 @@ class ChildChainService(object):
         return response["result"]
 
     def apply_transaction(self, transaction):
-        return self.send_request("apply_transaction", [transaction])
+        return self.send_request("apply_transaction", [rlp.encode(transaction, Transaction).hex()])
 
     def submit_block(self, block):
-        return self.send_request("submit_block", [block])
+        return self.send_request("submit_block", [rlp.encode(block, Block).hex()])
 
     def get_transaction(self, blknum, txindex):
         return self.send_request("get_transaction", [blknum, txindex])

--- a/plasma/client/child_chain_service.py
+++ b/plasma/client/child_chain_service.py
@@ -1,8 +1,5 @@
 import requests
-import rlp
 from plasma.child_chain.child_chain import ChildChain
-from plasma.child_chain.transaction import Transaction
-from plasma.child_chain.block import Block
 
 
 class ChildChainService(object):
@@ -22,10 +19,10 @@ class ChildChainService(object):
         return response["result"]
 
     def apply_transaction(self, transaction):
-        return self.send_request("apply_transaction", [rlp.encode(transaction, Transaction).hex()])
+        return self.send_request("apply_transaction", [transaction])
 
     def submit_block(self, block):
-        return self.send_request("submit_block", [rlp.encode(block, Block).hex()])
+        return self.send_request("submit_block", [block])
 
     def get_transaction(self, blknum, txindex):
         return self.send_request("get_transaction", [blknum, txindex])

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -1,5 +1,7 @@
 import rlp
+from ethereum import utils
 from web3 import HTTPProvider
+from plasma.child_chain.block import Block
 from plasma.config import plasma_config
 from plasma.root_chain.deployer import Deployer
 from plasma.child_chain.transaction import Transaction, UnsignedTransaction
@@ -51,10 +53,12 @@ class Client(object):
         return self.child_chain.get_transaction(blknum, txindex)
 
     def get_current_block(self):
-        return self.child_chain.get_current_block()
+        encoded_block = self.child_chain.get_current_block()
+        return rlp.decode(utils.decode_hex(encoded_block), Block)
 
     def get_block(self, blknum):
-        return self.child_chain.get_block(blknum)
+        encoded_block = self.child_chain.get_block(blknum)
+        return rlp.decode(utils.decode_hex(encoded_block), Block)
 
     def get_current_block_num(self):
         return self.child_chain.get_current_block_num()

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -37,14 +37,17 @@ class Client(object):
         self.root_chain.deposit(transact={'from': owner, 'value': amount})
 
     def apply_transaction(self, transaction):
-        self.child_chain.apply_transaction(transaction)
+        encoded_transaction = rlp.encode(transaction, Transaction).hex()
+        self.child_chain.apply_transaction(encoded_transaction)
 
     def submit_block(self, block):
-        self.child_chain.submit_block(block)
+        encoded_block = rlp.encode(block, Block).hex()
+        self.child_chain.submit_block(encoded_block)
 
     def withdraw(self, blknum, txindex, oindex, tx, proof, sigs):
         utxo_pos = blknum * 1000000000 + txindex * 10000 + oindex * 1
-        self.root_chain.startExit(utxo_pos, rlp.encode(tx, UnsignedTransaction), proof, sigs, transact={'from': '0x' + tx.newowner1.hex()})
+        encoded_transaction = rlp.encode(tx, UnsignedTransaction)
+        self.root_chain.startExit(utxo_pos, encoded_transaction, proof, sigs, transact={'from': '0x' + tx.newowner1.hex()})
 
     def withdraw_deposit(self, owner, deposit_pos, amount):
         self.root_chain.startDepositExit(deposit_pos, amount, transact={'from': owner})

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -37,12 +37,10 @@ class Client(object):
         self.root_chain.deposit(transact={'from': owner, 'value': amount})
 
     def apply_transaction(self, transaction):
-        encoded_transaction = rlp.encode(transaction, Transaction).hex()
-        self.child_chain.apply_transaction(encoded_transaction)
+        self.child_chain.apply_transaction(transaction)
 
     def submit_block(self, block):
-        encoded_block = rlp.encode(block, Block).hex()
-        self.child_chain.submit_block(encoded_block)
+        self.child_chain.submit_block(block)
 
     def withdraw(self, blknum, txindex, oindex, tx, proof, sigs):
         utxo_pos = blknum * 1000000000 + txindex * 10000 + oindex * 1

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -53,7 +53,8 @@ class Client(object):
         self.root_chain.startDepositExit(deposit_pos, amount, transact={'from': owner})
 
     def get_transaction(self, blknum, txindex):
-        return self.child_chain.get_transaction(blknum, txindex)
+        encoded_transaction = self.child_chain.get_transaction(blknum, txindex)
+        return rlp.decode(utils.decode_hex(encoded_transaction), Transaction)
 
     def get_current_block(self):
         encoded_block = self.child_chain.get_current_block()


### PR DESCRIPTION
This is meant to fix #100. 
The CLI no longer decodes blocks, rather the client decodes before returning.
I was unsure if the child_chain should decode applied transactions and submitted blocks, but left this as is, as tests would fail otherwise. 

Should decodes be moved out of child_chain along with the refactoring of tests to accommodate?