### PR TITLE
In RootChain, changed depositBLock to depositBlock

### DIFF
--- a/plasma/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain/RootChain.sol
@@ -23,7 +23,7 @@ contract RootChain {
      */
     event Deposit(
         address indexed depositor,
-        uint256 indexed depositBLock,
+        uint256 indexed depositBlock,
         uint256 amount
     );
 


### PR DESCRIPTION
Hello, in fcf2924, ```depositBlock``` is defined as ```depositBLock```, I believe this was a typo. 