### PR TITLE
Change Solidity v0.4.18 Homebrew url to support macOS 10.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ First, install [vcpkg](https://github.com/Microsoft/vcpkg). Then,
 Mac:
 ```
 $ brew unlink solidity
-$ brew install https://raw.githubusercontent.com/ethereum/homebrew-ethereum/2aea171d7d6901b97d5f1f71bd07dd88ed5dfb42/solidity.rb
+$ brew install https://raw.githubusercontent.com/jckdotim/homebrew-ethereum/v0.4.18/solidity.rb
 ```
 
 Linux:


### PR DESCRIPTION
Current old Solidity v0.4.18 homebrew script doesn't work on macOS 10.13.
So I fixed this to work on recent macOS. 