### PR TITLE
Break utils into different files

### DIFF
--- a/plasma/child_chain/child_chain.py
+++ b/plasma/child_chain/child_chain.py
@@ -1,7 +1,7 @@
 import rlp
 from ethereum import utils
 from plasma_core.constants import NULL_ADDRESS, NULL_SIGNATURE
-from plasma_core.utils.utils import unpack_utxo_pos
+from plasma_core.utils.transactions import decode_utxo_id
 from plasma_core.block import Block
 from plasma_core.transaction import Transaction
 from .exceptions import (InvalidBlockMerkleException,
@@ -31,7 +31,7 @@ class ChildChain(object):
     def apply_exit(self, event):
         event_args = event['args']
         utxo_pos = event_args['utxoPos']
-        self.mark_utxo_spent(*unpack_utxo_pos(utxo_pos))
+        self.mark_utxo_spent(*decode_utxo_id(utxo_pos))
 
     def apply_deposit(self, event):
         event_args = event['args']

--- a/plasma_core/block.py
+++ b/plasma_core/block.py
@@ -2,7 +2,7 @@ import rlp
 from rlp.sedes import binary, CountableList
 from ethereum import utils
 from plasma_core.utils.merkle.fixed_merkle import FixedMerkle
-from plasma_core.utils.utils import sign, get_sender
+from plasma_core.utils.signatures import sign, get_signer
 from plasma_core.transaction import Transaction
 from plasma_core.constants import NULL_SIGNATURE
 
@@ -28,7 +28,7 @@ class Block(rlp.Serializable):
 
     @property
     def sender(self):
-        return get_sender(self.hash, self.sig)
+        return get_signer(self.hash, self.sig)
 
     def merklize_transaction_set(self):
         hashed_transaction_set = [transaction.merkle_hash for transaction in self.transaction_set]

--- a/plasma_core/exceptions.py
+++ b/plasma_core/exceptions.py
@@ -1,0 +1,18 @@
+class TxAlreadySpentException(Exception):
+    """the transaction is already spent"""
+
+
+class InvalidTxSignatureException(Exception):
+    """the signature of a tx is invalid"""
+
+
+class InvalidBlockSignatureException(Exception):
+    """the signature of a block is invalid"""
+
+
+class TxAmountMismatchException(Exception):
+    """tx input total amount is not equal to output total amount"""
+
+
+class InvalidBlockMerkleException(Exception):
+    """merkle tree of a block is invalid"""

--- a/plasma_core/transaction.py
+++ b/plasma_core/transaction.py
@@ -1,7 +1,7 @@
 import rlp
 from rlp.sedes import big_endian_int, binary
 from ethereum import utils
-from plasma_core.utils.utils import get_sender, sign
+from plasma_core.utils.signatures import get_signer, sign
 from plasma_core.constants import NULL_SIGNATURE
 
 
@@ -81,11 +81,11 @@ class Transaction(rlp.Serializable):
 
     @property
     def sender1(self):
-        return get_sender(self.hash, self.sig1)
+        return get_signer(self.hash, self.sig1)
 
     @property
     def sender2(self):
-        return get_sender(self.hash, self.sig2)
+        return get_signer(self.hash, self.sig2)
 
 
 UnsignedTransaction = Transaction.exclude(['sig1', 'sig2'])

--- a/plasma_core/utils/address.py
+++ b/plasma_core/utils/address.py
@@ -1,0 +1,6 @@
+def address_to_hex(address):
+    return '0x' + address.hex()
+
+
+def address_to_bytes(address):
+    return bytes.fromhex(address[2:])

--- a/plasma_core/utils/signatures.py
+++ b/plasma_core/utils/signatures.py
@@ -1,0 +1,18 @@
+from ethereum import utils as u
+
+
+def sign(hash, key):
+    vrs = u.ecsign(hash, key)
+    rsv = vrs[1:] + vrs[:1]
+    vrs_bytes = [u.encode_int32(i) for i in rsv[:2]] + [u.int_to_bytes(rsv[2])]
+    return b''.join(vrs_bytes)
+
+
+def get_signer(hash, sig):
+    v = sig[64]
+    if v < 27:
+        v += 27
+    r = u.bytes_to_int(sig[:32])
+    s = u.bytes_to_int(sig[32:64])
+    pub = u.ecrecover_to_pub(hash, v, r, s)
+    return u.sha3(pub)[-20:]

--- a/plasma_core/utils/transactions.py
+++ b/plasma_core/utils/transactions.py
@@ -1,0 +1,18 @@
+BLKNUM_OFFSET = 1000000000
+TXINDEX_OFFSET = 10000
+
+
+def decode_utxo_id(utxo_id):
+    blknum = utxo_id // BLKNUM_OFFSET
+    txindex = (utxo_id % BLKNUM_OFFSET) // BLKNUM_OFFSET
+    oindex = utxo_id - blknum * BLKNUM_OFFSET - txindex * TXINDEX_OFFSET
+    return (blknum, txindex, oindex)
+
+
+def encode_utxo_id(blknum, txindex, oindex):
+    return (blknum * BLKNUM_OFFSET) + (txindex * TXINDEX_OFFSET) + (oindex * 1)
+
+
+def decode_tx_id(utxo_id):
+    (blknum, txindex, _) = decode_utxo_id(utxo_id)
+    return encode_utxo_id(blknum, txindex, 0)

--- a/plasma_core/utils/utils.py
+++ b/plasma_core/utils/utils.py
@@ -1,11 +1,12 @@
 from ethereum import utils as u
 from plasma_core.constants import NULL_HASH
+from plasma_core.utils.signatures import sign
 from plasma_core.utils.merkle.fixed_merkle import FixedMerkle
 
 
 def get_empty_merkle_tree_hash(depth):
     zeroes_hash = NULL_HASH
-    for i in range(depth):
+    for _ in range(depth):
         zeroes_hash = u.sha3(zeroes_hash + zeroes_hash)
     return zeroes_hash
 
@@ -18,37 +19,9 @@ def bytes_fill_left(inp, length):
     return bytes(length - len(inp)) + inp
 
 
-def confirm_tx(tx, root, key):
-    return sign(u.sha3(tx.hash + root), key)
-
-
 def get_deposit_hash(owner, token, value):
     return u.sha3(owner + token + b'\x00' * 31 + u.int_to_bytes(value))
 
 
-def sign(hash, key):
-    vrs = u.ecsign(hash, key)
-    rsv = vrs[1:] + vrs[:1]
-    vrs_bytes = [u.encode_int32(i) for i in rsv[:2]] + [u.int_to_bytes(rsv[2])]
-    return b''.join(vrs_bytes)
-
-
-def get_sender(hash, sig):
-    v = sig[64]
-    if v < 27:
-        v += 27
-    r = u.bytes_to_int(sig[:32])
-    s = u.bytes_to_int(sig[32:64])
-    pub = u.ecrecover_to_pub(hash, v, r, s)
-    return u.sha3(pub)[-20:]
-
-
-def unpack_utxo_pos(utxo_pos):
-    blknum = utxo_pos // 1000000000
-    txindex = (utxo_pos % 1000000000) // 10000
-    oindex = utxo_pos - blknum * 1000000000 - txindex * 10000
-    return (blknum, txindex, oindex)
-
-
-def pack_utxo_pos(blknum, txindex, oindex):
-    return (blknum * 1000000000) + (txindex * 10000) + (oindex * 1)
+def confirm_tx(tx, root, key):
+    return sign(u.sha3(tx.hash + root), key)

--- a/tests/child_chain/test_block.py
+++ b/tests/child_chain/test_block.py
@@ -1,7 +1,7 @@
 import pytest
 from plasma_core.block import Block
 from plasma_core.constants import NULL_SIGNATURE
-from plasma_core.utils.utils import sign, get_sender
+from plasma_core.utils.signatures import sign, get_signer
 
 
 @pytest.fixture
@@ -18,4 +18,4 @@ def test_initial_state(block):
 def test_signature(t, block):
     block.sign(t.k0)
     assert block.sig == sign(block.hash, t.k0)
-    assert block.sender == get_sender(block.hash, sign(block.hash, t.k0))
+    assert block.sender == get_signer(block.hash, sign(block.hash, t.k0))


### PR DESCRIPTION
Breaks `utils.py` into a few different files for readability. Updates imports to account for this change.