### PR TITLE
Update PriorityQueue

### DIFF
--- a/plasma/root_chain/contracts/PriorityQueue.sol
+++ b/plasma/root_chain/contracts/PriorityQueue.sol
@@ -5,104 +5,139 @@ import "./SafeMath.sol";
 
 /**
  * @title PriorityQueue
- * @dev A priority queue implementation
+ * @dev A priority queue implementation.
  */
 contract PriorityQueue {
     using SafeMath for uint256;
 
+    /* 
+     *  Storage
+     */
+
+    address owner;
+    uint256[] heapList;
+    uint256 public currentSize;
+
+
     /*
      *  Modifiers
      */
+
     modifier onlyOwner() {
         require(msg.sender == owner);
         _;
     }
 
-    /* 
-     *  Storage
-     */
-    address owner;
-    uint256[] heapList;
-    uint256 public currentSize;
 
-    function PriorityQueue()
-        public
-    {
+    /*
+     * Constructor
+     */
+
+    constructor() public {
         owner = msg.sender;
         heapList = [0];
         currentSize = 0;
     }
 
-    function insert(uint256 k) 
-        public
-        onlyOwner
-    {
-        heapList.push(k);
+
+    /*
+     * Internal functions
+     */
+
+    /**
+     * @dev Inserts an element into the priority queue.
+     * @param _priority Priority to insert.
+     * @param _value Some additional value.
+     */
+    function insert(uint256 _priority, uint256 _value) public onlyOwner {
+        uint256 element = _priority << 128 | _value;
+        heapList.push(element);
         currentSize = currentSize.add(1);
-        percUp(currentSize);
+        _percUp(currentSize);
     }
 
-    function minChild(uint256 i)
-        public
-        view
-        returns (uint256)
-    {
-        if (i.mul(2).add(1) > currentSize) {
-            return i.mul(2);
-        } else {
-            if (heapList[i.mul(2)] < heapList[i.mul(2).add(1)]) {
-                return i.mul(2);
-            } else {
-                return i.mul(2).add(1);
-            }
-        }
+    /**
+     * @dev Returns the top element of the heap.
+     * @return The smallest element in the priority queue.
+     */
+    function getMin() public view returns (uint256, uint256) {
+        return _splitElement(heapList[1]);
     }
 
-    function getMin()
-        public
-        view
-        returns (uint256)
-    {
-        return heapList[1];
-    }
-
-    function delMin()
-        public
-        onlyOwner
-        returns (uint256)
-    {
+    /**
+     * @dev Deletes the top element of the heap and shifts everything up.
+     * @return The smallest element in the priorty queue.
+     */
+    function delMin() public onlyOwner returns (uint256, uint256) {
         uint256 retVal = heapList[1];
         heapList[1] = heapList[currentSize];
         delete heapList[currentSize];
         currentSize = currentSize.sub(1);
-        percDown(1);
+        _percDown(1);
         heapList.length = heapList.length.sub(1);
-        return retVal;
+        return _splitElement(retVal);
     }
 
-    function percUp(uint256 i) 
-        private
-    {
-        uint256 j = i;
-        uint256 newVal = heapList[i];
-        while (newVal < heapList[i.div(2)]) {
-            heapList[i] = heapList[i.div(2)];
-            i = i.div(2);
+
+    /*
+     * Private functions
+     */
+
+    /**
+     * @dev Determines the minimum child of a given node in the tree.
+     * @param _index Index of the node in the tree.
+     * @return The smallest child node.
+     */
+    function _minChild(uint256 _index) private view returns (uint256) {
+        if (_index.mul(2).add(1) > currentSize) {
+            return _index.mul(2);
+        } else {
+            if (heapList[_index.mul(2)] < heapList[_index.mul(2).add(1)]) {
+                return _index.mul(2);
+            } else {
+                return _index.mul(2).add(1);
+            }
         }
-        if (i != j) heapList[i] = newVal;
     }
 
-    function percDown(uint256 i)
-        private
-    {
-        uint256 j = i;
-        uint256 newVal = heapList[i];
-        uint256 mc = minChild(i);
+    /**
+     * @dev Bubbles the element at some index up.
+     */
+    function _percUp(uint256 _index) private {
+        uint256 index = _index;
+        uint256 j = index;
+        uint256 newVal = heapList[index];
+        while (newVal < heapList[index.div(2)]) {
+            heapList[index] = heapList[index.div(2)];
+            index = index.div(2);
+        }
+        if (index != j) heapList[index] = newVal;
+    }
+
+    /**
+     * @dev Bubbles the element at some index down.
+     */
+    function _percDown(uint256 _index) private {
+        uint256 index = _index;
+        uint256 j = index;
+        uint256 newVal = heapList[index];
+        uint256 mc = _minChild(index);
         while (mc <= currentSize && newVal > heapList[mc]) {
-            heapList[i] = heapList[mc];
-            i = mc;
-            mc = minChild(i);
+            heapList[index] = heapList[mc];
+            index = mc;
+            mc = _minChild(index);
         }
-        if (i != j) heapList[i] = newVal;
+        if (index != j) heapList[index] = newVal;
+    }
+
+    /**
+     * @dev Split an element into its priority and value.
+     * @param _element Element to decode.
+     * @return A tuple containing the priority and value.
+     */
+    function _splitElement(uint256 _element) private pure returns (uint256, uint256) {
+        uint256 priority = _element >> 128;
+        uint256 value = uint256(uint128(_element));
+        return (priority, value);
     }
 }

--- a/tests/root_chain/contracts/data_structures/test_priority_queue.py
+++ b/tests/root_chain/contracts/data_structures/test_priority_queue.py
@@ -13,42 +13,48 @@ def test_priority_queue_get_min_empty_should_fail(priority_queue):
 
 
 def test_priority_queue_insert(priority_queue):
-    priority_queue.insert(2)
-    assert priority_queue.getMin() == 2
+    extra_value = 12345
+    priority_queue.insert(2, extra_value)
+    assert priority_queue.getMin() == [2, extra_value]
     assert priority_queue.currentSize() == 1
 
 
 def test_priority_queue_insert_multiple(priority_queue):
-    priority_queue.insert(2)
-    priority_queue.insert(5)
-    assert priority_queue.getMin() == 2
+    extra_value = 12345
+    priority_queue.insert(2, extra_value)
+    priority_queue.insert(5, extra_value)
+    assert priority_queue.getMin() == [2, extra_value]
     assert priority_queue.currentSize() == 2
 
 
 def test_priority_queue_insert_out_of_order(priority_queue):
-    priority_queue.insert(5)
-    priority_queue.insert(2)
-    assert priority_queue.getMin() == 2
+    extra_value = 12345
+    priority_queue.insert(5, extra_value)
+    priority_queue.insert(2, extra_value)
+    assert priority_queue.getMin() == [2, extra_value]
 
 
 def test_priority_queue_delete_min(priority_queue):
-    priority_queue.insert(2)
-    assert priority_queue.delMin() == 2
+    extra_value = 12345
+    priority_queue.insert(2, extra_value)
+    assert priority_queue.delMin() == [2, extra_value]
     assert priority_queue.currentSize() == 0
 
 
 def test_priority_queue_delete_all(priority_queue):
-    priority_queue.insert(5)
-    priority_queue.insert(2)
-    assert priority_queue.delMin() == 2
-    assert priority_queue.delMin() == 5
+    extra_value = 12345
+    priority_queue.insert(5, extra_value)
+    priority_queue.insert(2, extra_value)
+    assert priority_queue.delMin() == [2, extra_value]
+    assert priority_queue.delMin() == [5, extra_value]
     assert priority_queue.currentSize() == 0
     with pytest.raises(TransactionFailed):
         priority_queue.getMin()
 
 
 def test_priority_queue_delete_then_insert(priority_queue):
-    priority_queue.insert(2)
-    assert priority_queue.delMin() == 2
-    priority_queue.insert(5)
-    assert priority_queue.getMin() == 5
+    extra_value = 12345
+    priority_queue.insert(2, extra_value)
+    assert priority_queue.delMin() == [2, extra_value]
+    priority_queue.insert(5, extra_value)
+    assert priority_queue.getMin() == [5, extra_value]

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -32,7 +32,7 @@ def test_start_deposit_exit(t, u, root_chain, assert_tx_failed):
     expected_utxo_pos = blknum * 1000000000
     expected_exitable_at = t.chain.head_state.timestamp + two_weeks
     root_chain.startDepositExit(expected_utxo_pos, NULL_ADDRESS, value_1)
-    utxo_pos, exitable_at = root_chain.getNextExit(NULL_ADDRESS)
+    exitable_at, utxo_pos = root_chain.getNextExit(NULL_ADDRESS)
     assert utxo_pos == expected_utxo_pos
     assert exitable_at == expected_exitable_at
     assert root_chain.exits(utxo_pos) == ['0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1', NULL_ADDRESS_HEX, 100]
@@ -56,14 +56,14 @@ def test_start_fee_exit(t, u, root_chain, assert_tx_failed):
     assert root_chain.currentFeeExit() == 1
     root_chain.startFeeExit(NULL_ADDRESS, 1)
     assert root_chain.currentFeeExit() == 2
-    utxo_pos, exitable_at = root_chain.getNextExit(NULL_ADDRESS)
+    exitable_at, utxo_pos = root_chain.getNextExit(NULL_ADDRESS)
     fee_priority = exitable_at << 128 | utxo_pos
     assert utxo_pos == expected_utxo_pos
     assert exitable_at == expected_exitable_at
 
     expected_utxo_pos = blknum * 1000000000 + 1
     root_chain.startDepositExit(expected_utxo_pos, NULL_ADDRESS, value_1)
-    utxo_pos, created_at = root_chain.getNextExit(NULL_ADDRESS)
+    created_at, utxo_pos = root_chain.getNextExit(NULL_ADDRESS)
     deposit_priority = created_at << 128 | utxo_pos
     assert fee_priority > deposit_priority
     # Fails if transaction sender isn't the authority


### PR DESCRIPTION
Cleans up PriorityQueue and changes `insert` function so it takes a priority and some extra value. This hides the complexity of the `priority = priority << 128 | value` thing we're doing.