### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/__pycache__/
 
 # Development
-env/
+env*/
 .vscode/
 .DS_Store
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.6"
+  - "3.7"
 
 cache: pip
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Windows:
 choco install python
 ```
 
+#### [Ganache CLI 6.1.8+](https://github.com/trufflesuite/ganache-cli)
+
 ### Installation
 
 Note: we optionally recommend using something like [`virtualenv`](https://pypi.python.org/pypi/virtualenv) in order to create an isolated Python environment:
@@ -127,8 +129,6 @@ $ make lint
 ### Starting Plasma
 
 The fastest way to start playing with our Plasma MVP is by starting up `ganache-cli`, deploying everything locally, and running our CLI. Full documentation for the CLI is available [here](#cli-documentation).
-
-#### [Ganache 1.2.1+](https://github.com/trufflesuite/ganache/releases)
 
 ```bash
 $ ganache-cli -m=plasma_mvp # Start ganache-cli

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'ethereum==2.3.0',
-        'web3==4.3.0',
-        'werkzeug==0.13',
+        'web3==4.5.0',
         'json-rpc==1.10.8',
         'plyvel==1.0.4',
         'py-solc',


### PR DESCRIPTION
Fixes #172, #167 

Adds support for Python 3.7 by upgrading Web3 to 4.5.0. Tests pass on Ganache 6.1.8.