### PR TITLE
Solution to Issue 162

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 env/
 .vscode/
 .DS_Store
+.idea/*
 
 # Distibution
 dist/

--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ Creates a transaction and submits it to the child chain.
 #### Usage
 
 ```
-sendtx <blknum1> <txindex1> <oindex1> <blknum2> <txindex2> <oindex2> <newowner1> <amount1> <newowner2> <amount2> <fee> <key1> [<key2>]
+sendtx <blknum1> <txindex1> <oindex1> <blknum2> <txindex2> <oindex2> <cur12> <newowner1> <amount1> <newowner2> <amount2> <fee> <key1> [<key2>]
 ```
 
 #### Example
 
 ```
-send_tx 1 0 0 0 0 0 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7 50 0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26 45 5 3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304
+send_tx 1 0 0 0 0 0 0x0 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7 50 0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26 45 5 3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304
 ```
 
 ### `submitblock`
@@ -247,7 +247,7 @@ omg deposit 100 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7
 
 3. Send a transaction:
 ```
-omg sendtx 1 0 0 0 0 0 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7 50 0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26 45 5 3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304
+omg sendtx 1 0 0 0 0 0 0x0 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7 50 0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26 45 5 3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304
 ```
 
 4.  Submit the block:

--- a/plasma/child_chain/child_chain.py
+++ b/plasma/child_chain/child_chain.py
@@ -1,5 +1,9 @@
+import rlp
+from ethereum import utils
+
 from plasma_core.block import Block
 from plasma_core.chain import Chain
+from plasma_core.transaction import Transaction
 from plasma_core.utils.transactions import get_deposit_tx, encode_utxo_id
 from .root_event_listener import RootEventListener
 
@@ -32,7 +36,11 @@ class ChildChain(object):
         deposit_block = Block([deposit_tx], number=blknum)
         self.chain.add_block(deposit_block)
 
-    def apply_transaction(self, tx):
+    def apply_transaction(self, encoded_transaction):
+        try:
+            tx = rlp.decode(utils.decode_hex(encoded_transaction), Transaction)
+        except TypeError:
+            tx = encoded_transaction
         self.chain.validate_transaction(tx, self.current_block.spent_utxos)
         self.current_block.add_transaction(tx)
         return encode_utxo_id(self.current_block.number, len(self.current_block.transaction_set) - 1, 0)


### PR DESCRIPTION
This fix includes two minor changes and one medium (temporary fix)

- [tiny] update README (specifically sendtx example)
- [tiny] update gitignore to exclude IDE files
- [medium] update child_chain.py to handle situations when hex-encoded transaction is passed instead of transaction object.