### PR TITLE
Fix rootchain tests

### DIFF
--- a/plasma/cli/cli.py
+++ b/plasma/cli/cli.py
@@ -3,6 +3,7 @@ from ethereum import utils
 from plasma_core.constants import NULL_ADDRESS
 from plasma_core.transaction import Transaction
 from plasma_core.utils.utils import confirm_tx
+from plasma_core.utils.transactions import encode_utxo_id
 from plasma.client.client import Client
 from plasma.client.exceptions import ChildChainServiceError
 
@@ -136,7 +137,7 @@ def withdraw(client,
 @click.argument('amount', required=True, type=int)
 @click.pass_obj
 def withdrawdeposit(client, owner, blknum, amount):
-    deposit_pos = blknum * 1000000000
+    deposit_pos = encode_utxo_id(blknum, 0, 0)
     client.withdraw_deposit(owner, deposit_pos, amount)
     print("Submitted withdrawal")
 

--- a/plasma/client/client.py
+++ b/plasma/client/client.py
@@ -4,6 +4,7 @@ from web3 import HTTPProvider
 from plasma_core.block import Block
 from plasma_core.transaction import Transaction, UnsignedTransaction
 from plasma_core.constants import NULL_ADDRESS, CONTRACT_ADDRESS
+from plasma_core.utils.transactions import encode_utxo_id
 from plasma.root_chain.deployer import Deployer
 from .child_chain_service import ChildChainService
 
@@ -45,7 +46,7 @@ class Client(object):
         self.child_chain.submit_block(block)
 
     def withdraw(self, blknum, txindex, oindex, tx, proof, sigs):
-        utxo_pos = blknum * 1000000000 + txindex * 10000 + oindex * 1
+        utxo_pos = encode_utxo_id(blknum, txindex, oindex)
         encoded_transaction = rlp.encode(tx, UnsignedTransaction)
         self.root_chain.startExit(utxo_pos, encoded_transaction, proof, sigs, transact={'from': '0x' + tx.newowner1.hex()})
 

--- a/plasma/root_chain/contracts/ECRecovery.sol
+++ b/plasma/root_chain/contracts/ECRecovery.sol
@@ -23,7 +23,7 @@ library ECRecovery {
 
         // Check the signature length.
         if (_sig.length != 65) {
-            return address(0);
+            revert("Invalid signature length.");
         }
 
         // Divide the signature in v, r, and s variables.
@@ -40,7 +40,7 @@ library ECRecovery {
 
         // If the version is correct return the signer address.
         if (v != 27 && v != 28) {
-            return address(0);
+            revert("Invalid signature version.");
         } else {
             return ecrecover(_hash, v, r, s);
         }

--- a/plasma/root_chain/contracts/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain.sol
@@ -128,14 +128,11 @@ contract RootChain {
     /**
      * @dev Allows anyone to deposit funds into the Plasma chain.
      */
-    function deposit()
-        public
-        payable
-    {
+    function deposit() public payable {
         // Only allow up to CHILD_BLOCK_INTERVAL deposits per child block.
-        require(currentDepositBlock < CHILD_BLOCK_INTERVAL);
+        require(currentDepositBlock < CHILD_BLOCK_INTERVAL, "Deposit limit reached.");
 
-        bytes32 root = keccak256(msg.sender, address(0), msg.value);
+        bytes32 root = keccak256(abi.encodePacked(msg.sender, address(0), msg.value));
         uint256 depositBlock = getDepositBlock();
         plasmaBlocks[depositBlock] = PlasmaBlock({
             root: root,

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -3,6 +3,7 @@ import rlp
 from plasma_core.transaction import Transaction, UnsignedTransaction
 from plasma_core.utils.merkle.fixed_merkle import FixedMerkle
 from plasma_core.utils.utils import confirm_tx, get_deposit_hash
+from plasma_core.utils.transactions import encode_utxo_id
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX
 
 
@@ -29,7 +30,7 @@ def test_start_deposit_exit(t, u, root_chain, assert_tx_failed):
     root_chain.deposit(value=value_1)
     blknum = root_chain.getDepositBlock()
     root_chain.deposit(value=value_1)
-    expected_utxo_pos = blknum * 1000000000
+    expected_utxo_pos = encode_utxo_id(blknum, 0, 0)
     expected_exitable_at = t.chain.head_state.timestamp + two_weeks
     root_chain.startDepositExit(expected_utxo_pos, NULL_ADDRESS, value_1)
     exitable_at, utxo_pos = root_chain.getNextExit(NULL_ADDRESS)
@@ -61,7 +62,7 @@ def test_start_fee_exit(t, u, root_chain, assert_tx_failed):
     assert utxo_pos == expected_utxo_pos
     assert exitable_at == expected_exitable_at
 
-    expected_utxo_pos = blknum * 1000000000 + 1
+    expected_utxo_pos = encode_utxo_id(blknum, 0, 0)
     root_chain.startDepositExit(expected_utxo_pos, NULL_ADDRESS, value_1)
     created_at, utxo_pos = root_chain.getNextExit(NULL_ADDRESS)
     deposit_priority = created_at << 128 | utxo_pos
@@ -83,18 +84,17 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     merkle = FixedMerkle(16, [deposit_tx_hash], True)
     proof = merkle.create_membership_proof(deposit_tx_hash)
     confirmSig1 = confirm_tx(tx1, root_chain.getPlasmaBlock(dep_blknum)[0], key)
-    priority1 = dep_blknum * 1000000000 + 10000 * 0 + 1
     snapshot = t.chain.snapshot()
     sigs = tx1.sig1 + tx1.sig2 + confirmSig1
-    utxoId = dep_blknum * 1000000000 + 10000 * 0 + 1
+    utxoId = encode_utxo_id(dep_blknum, 0, 0)
     # Deposit exit
     root_chain.startDepositExit(utxoId, NULL_ADDRESS, tx1.amount1, sender=key)
 
     t.chain.head_state.timestamp += week_and_a_half
     # Cannot exit twice off of the same utxo
-    utxo_pos1 = dep_blknum * 1000000000 + 10000 * 0 + 1
+    utxo_pos1 = encode_utxo_id(dep_blknum, 0, 0)
     assert_tx_failed(lambda: root_chain.startExit(utxo_pos1, deposit_tx_hash, proof, sigs, sender=key))
-    assert root_chain.getExit(priority1) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
+    assert root_chain.getExit(utxo_pos1) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
     t.chain.revert(snapshot)
 
     tx2 = Transaction(dep_blknum, 0, 0, 0, 0, 0,
@@ -108,13 +108,12 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     assert child_blknum == 1000
     root_chain.submitBlock(merkle.root)
     confirmSig1 = confirm_tx(tx2, root_chain.getPlasmaBlock(child_blknum)[0], key)
-    priority2 = child_blknum * 1000000000 + 10000 * 0 + 0
     sigs = tx2.sig1 + tx2.sig2 + confirmSig1
     snapshot = t.chain.snapshot()
     # # Single input exit
-    utxo_pos2 = child_blknum * 1000000000 + 10000 * 0 + 0
+    utxo_pos2 = encode_utxo_id(child_blknum, 0, 0)
     root_chain.startExit(utxo_pos2, tx_bytes2, proof, sigs, sender=key)
-    assert root_chain.getExit(priority2) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
+    assert root_chain.getExit(utxo_pos2) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
     t.chain.revert(snapshot)
     dep2_blknum = root_chain.getDepositBlock()
     assert dep2_blknum == 1001
@@ -132,12 +131,11 @@ def test_start_exit(t, root_chain, assert_tx_failed):
     root_chain.submitBlock(merkle.root)
     confirmSig1 = confirm_tx(tx3, root_chain.getPlasmaBlock(child2_blknum)[0], key)
     confirmSig2 = confirm_tx(tx3, root_chain.getPlasmaBlock(child2_blknum)[0], key)
-    priority3 = child2_blknum * 1000000000 + 10000 * 0 + 0
     sigs = tx3.sig1 + tx3.sig2 + confirmSig1 + confirmSig2
     # Double input exit
-    utxoPos3 = child2_blknum * 1000000000 + 10000 * 0 + 0
-    root_chain.startExit(utxoPos3, tx_bytes3, proof, sigs, sender=key)
-    assert root_chain.getExit(priority3) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
+    utxo_pos3 = encode_utxo_id(child2_blknum, 0, 0)
+    root_chain.startExit(utxo_pos3, tx_bytes3, proof, sigs, sender=key)
+    assert root_chain.getExit(utxo_pos3) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
 
 
 def test_challenge_exit(t, u, root_chain, assert_tx_failed):
@@ -146,9 +144,9 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
                       NULL_ADDRESS,
                       owner, value_1, NULL_ADDRESS, 0)
     deposit_tx_hash = get_deposit_hash(owner, NULL_ADDRESS, value_1)
-    utxo_pos1 = root_chain.getDepositBlock() * 1000000000 + 1
+    utxo_pos1 = encode_utxo_id(root_chain.getDepositBlock(), 0, 0)
     root_chain.deposit(value=value_1, sender=key)
-    utxo_pos2 = root_chain.getDepositBlock() * 1000000000
+    utxo_pos2 = encode_utxo_id(root_chain.getDepositBlock(), 0, 0)
     root_chain.deposit(value=value_1, sender=key)
     merkle = FixedMerkle(16, [deposit_tx_hash], True)
     proof = merkle.create_membership_proof(deposit_tx_hash)
@@ -166,7 +164,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     root_chain.submitBlock(merkle.root)
     confirmSig = confirm_tx(tx3, root_chain.getPlasmaBlock(child_blknum)[0], key)
     sigs = tx3.sig1 + tx3.sig2
-    utxo_pos3 = child_blknum * 1000000000 + 10000 * 0 + 0
+    utxo_pos3 = encode_utxo_id(child_blknum, 0, 0)
     tx4 = Transaction(utxo_pos1, 0, 0, 0, 0, 0,
                       NULL_ADDRESS,
                       owner, value_1, NULL_ADDRESS, 0)
@@ -178,7 +176,7 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     root_chain.submitBlock(merkle.root)
     confirmSig = confirm_tx(tx4, root_chain.getPlasmaBlock(child_blknum)[0], key)
     sigs = tx4.sig1 + tx4.sig2
-    utxo_pos4 = child_blknum * 1000000000 + 10000 * 0 + 0
+    utxo_pos4 = encode_utxo_id(child_blknum, 0, 0)
     oindex1 = 0
     assert root_chain.exits(utxo_pos1) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
     # Fails if transaction after exit doesn't reference the utxo being exited
@@ -199,7 +197,7 @@ def test_finalize_exits(t, u, root_chain):
                       owner, value_1, NULL_ADDRESS, 0)
     dep1_blknum = root_chain.getDepositBlock()
     root_chain.deposit(value=value_1, sender=key)
-    utxo_pos1 = dep1_blknum * 1000000000 + 10000 * 0 + 1
+    utxo_pos1 = encode_utxo_id(dep1_blknum, 0, 0)
     root_chain.startDepositExit(utxo_pos1, NULL_ADDRESS, tx1.amount1, sender=key)
     t.chain.head_state.timestamp += two_weeks * 2
     assert root_chain.exits(utxo_pos1) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -180,11 +180,11 @@ def test_challenge_exit(t, u, root_chain, assert_tx_failed):
     oindex1 = 0
     assert root_chain.exits(utxo_pos1) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
     # Fails if transaction after exit doesn't reference the utxo being exited
-    assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos3, utxo_pos1, tx_bytes3, proof, sigs, confirmSig))
+    assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos3, oindex1, tx_bytes3, proof, sigs, confirmSig))
     # Fails if transaction proof is incorrect
-    assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos4, utxo_pos1, tx_bytes4, proof[::-1], sigs, confirmSig))
+    assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos4, oindex1, tx_bytes4, proof[::-1], sigs, confirmSig))
     # Fails if transaction confirmation is incorrect
-    assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos4, utxo_pos1, tx_bytes4, proof, sigs, confirmSig[::-1]))
+    assert_tx_failed(lambda: root_chain.challengeExit(utxo_pos4, oindex1, tx_bytes4, proof, sigs, confirmSig[::-1]))
     root_chain.challengeExit(utxo_pos4, oindex1, tx_bytes4, proof, sigs, confirmSig)
     assert root_chain.exits(utxo_pos1) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, value_1]
 


### PR DESCRIPTION
Closes #182

We had an error in our root chain tests, where a UTXO position was being used instead of an output index. This would automatically cause an error. However, we were expecting this to throw & didn't see this as a result. 