### PR TITLE
Make send transaction work on new chain and added reporting exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ sendtx <blknum1> <txindex1> <oindex1> <blknum2> <txindex2> <oindex2> <cur12> <ne
 #### Example
 
 ```
-sendtx 1 0 0 0 0 0 0x0 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7 50 0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26 45 3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304
+sendtx 0 0 0 0 0 0 0x0 0xfd02EcEE62797e75D86BCff1642EB0844afB28c7 50 0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26 45 3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304
 ```
 
 ### `submitblock`

--- a/plasma_core/chain.py
+++ b/plasma_core/chain.py
@@ -7,6 +7,7 @@ from plasma_core.exceptions import (InvalidBlockSignatureException,
                                     BlockDoesNotExistException,
                                     TxAmountMismatchException)
 
+
 class Chain(object):
 
     def __init__(self, operator):

--- a/plasma_core/chain.py
+++ b/plasma_core/chain.py
@@ -4,12 +4,8 @@ from plasma_core.constants import NULL_SIGNATURE
 from plasma_core.exceptions import (InvalidBlockSignatureException,
                                     InvalidTxSignatureException,
                                     TxAlreadySpentException,
-                                    #BlockDoesNotExistException,
+                                    BlockDoesNotExistException,
                                     TxAmountMismatchException)
-# TODO: Move to exception class
-class BlockDoesNotExistException(Exception):
-    """that block doesn't exist in the current chain"""
-
 
 class Chain(object):
 

--- a/plasma_core/chain.py
+++ b/plasma_core/chain.py
@@ -4,7 +4,11 @@ from plasma_core.constants import NULL_SIGNATURE
 from plasma_core.exceptions import (InvalidBlockSignatureException,
                                     InvalidTxSignatureException,
                                     TxAlreadySpentException,
+                                    #BlockDoesNotExistException,
                                     TxAmountMismatchException)
+# TODO: Move to exception class
+class BlockDoesNotExistException(Exception):
+    """that block doesn't exist in the current chain"""
 
 
 class Chain(object):
@@ -59,6 +63,9 @@ class Chain(object):
             # Transactions coming from block 0 are valid.
             if blknum == 0:
                 continue
+
+            if not (blknum in self.blocks):
+                raise BlockDoesNotExistException('block index %d is not in the blocklist' % blknum)
 
             input_tx = self.blocks[blknum].transaction_set[txindex]
 

--- a/plasma_core/exceptions.py
+++ b/plasma_core/exceptions.py
@@ -16,3 +16,6 @@ class TxAmountMismatchException(Exception):
 
 class InvalidBlockMerkleException(Exception):
     """merkle tree of a block is invalid"""
+
+class BlockDoesNotExistException(Exception):
+    """that block doesn't exist in the current chain"""

--- a/plasma_core/exceptions.py
+++ b/plasma_core/exceptions.py
@@ -17,5 +17,6 @@ class TxAmountMismatchException(Exception):
 class InvalidBlockMerkleException(Exception):
     """merkle tree of a block is invalid"""
 
+
 class BlockDoesNotExistException(Exception):
     """that block doesn't exist in the current chain"""


### PR DESCRIPTION
When I tried to install and run the plasma MVP, I was getting the following error:

API Exception: {'type': 'KeyError', 'args': (1,), 'message': '1'}
Traceback (most recent call last):
  File "/home/drahmel/plasma-mvp/env/lib/python3.6/site-packages/json_rpc-1.10.8-py3.6.egg/jsonrpc/manager.py", line 112, in _get_responses
    result = method(*request.args, **request.kwargs)
  File "plasma/child_chain/server.py", line 21, in <lambda>
    dispatcher["apply_transaction"] = lambda transaction: child_chain.apply_transaction(rlp.decode(utils.decode_hex(transaction), Transaction))
  File "/home/drahmel/plasma-mvp/plasma/child_chain/child_chain.py", line 37, in apply_transaction
    self.chain.validate_transaction(tx, self.current_block.spent_utxos)
  File "/home/drahmel/plasma-mvp/plasma_core/chain.py", line 63, in validate_transaction
    input_tx = self.blocks[blknum].transaction_set[txindex]
KeyError: 1

I tracked it down to a reference to index 1 in the block list which was invalid. If I changed the example to start at index 0, it appeared to work properly.

I changed the example code to use index 0 and also added an exception that caught and described the problem.

When I run the tests, some of the child chain tests now fail throwing the new exception. I don't know the code well enough to know if this is catching a previously silent error or if I have to modify the tests to accommodate the new exception type. 

Any feedback would be greatly appreciated.
