### PR TITLE
Fix index iteration while checking membership of Merkle tree

### DIFF
--- a/plasma/root_chain/contracts/Merkle.sol
+++ b/plasma/root_chain/contracts/Merkle.sol
@@ -9,7 +9,7 @@ library Merkle {
     /*
      * Internal function
      */
-    
+
     /**
      * @dev Checks that a leaf is actually in a Merkle tree.
      * @param _leaf Leaf to verify.
@@ -35,7 +35,7 @@ library Merkle {
             assembly {
                 proofElement := mload(add(_proof, i))
             }
-            if (_index % 2 == 0) {
+            if (index % 2 == 0) {
                 computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
             } else {
                 computedHash = keccak256(abi.encodePacked(proofElement, computedHash));


### PR DESCRIPTION
Right side hashing would never occur as `_index` never changed from `0`. Changed the conditional to `index` in order to map the correct index value upon iteration of multiple leaves.