### PR TITLE
Migrate to Solidity v0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 install:
   - nvm install $NODE_VERSION
   - npm install --global ganache-cli
-  - wget https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux && chmod +x ./solc-static-linux && sudo mv solc-static-linux /usr/bin/solc
+  - wget https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux && chmod +x ./solc-static-linux && sudo mv solc-static-linux /usr/bin/solc
   - pip install --upgrade pip setuptools flake8
   - make
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plasma MVP is split into four main parts: `root_chain`, `child_chain`, `client`,
 
 This project has a few pre-installation dependencies.
 
-#### [Solidity](https://solidity.readthedocs.io/en/latest/installing-solidity.html)
+#### [Solidity ^0.5.0](https://solidity.readthedocs.io/en/latest/installing-solidity.html)
 
 Mac:
 ```sh

--- a/plasma/root_chain/contracts/ByteUtils.sol
+++ b/plasma/root_chain/contracts/ByteUtils.sol
@@ -17,7 +17,7 @@ library ByteUtils {
      * @param _length Length of the slice.
      * @return The slice of the byte string.
      */
-    function slice(bytes _bytes, uint _start, uint _length) internal pure returns (bytes) {
+    function slice(bytes memory _bytes, uint _start, uint _length) internal pure returns (bytes memory) {
         require(_bytes.length >= (_start + _length), "Slice length cannot be longer than _bytes length");
 
         bytes memory tempBytes;

--- a/plasma/root_chain/contracts/ByteUtils.sol
+++ b/plasma/root_chain/contracts/ByteUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/ECRecovery.sol
+++ b/plasma/root_chain/contracts/ECRecovery.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/ECRecovery.sol
+++ b/plasma/root_chain/contracts/ECRecovery.sol
@@ -16,7 +16,7 @@ library ECRecovery {
      * @param _sig Signature over the signed message.
      * @return Address that signed the hash.
      */
-    function recover(bytes32 _hash, bytes _sig) internal pure returns (address) {
+    function recover(bytes32 _hash, bytes memory _sig) internal pure returns (address) {
         bytes32 r;
         bytes32 s;
         uint8 v;

--- a/plasma/root_chain/contracts/Math.sol
+++ b/plasma/root_chain/contracts/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/Merkle.sol
+++ b/plasma/root_chain/contracts/Merkle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/Merkle.sol
+++ b/plasma/root_chain/contracts/Merkle.sol
@@ -22,7 +22,7 @@ library Merkle {
         bytes32 _leaf,
         uint256 _index,
         bytes32 _rootHash,
-        bytes _proof
+        bytes memory _proof
     ) internal pure returns (bool) {
         // Check that the proof length is valid.
         require(_proof.length % 32 == 0, "Invalid proof length.");

--- a/plasma/root_chain/contracts/PlasmaRLP.sol
+++ b/plasma/root_chain/contracts/PlasmaRLP.sol
@@ -6,7 +6,7 @@ import "./RLPDecode.sol";
 library PlasmaRLP {
 
     struct exitingTx {
-        address exitor;
+        address payable exitor;
         address token;
         uint256 amount;
         uint256 inputCount;
@@ -31,6 +31,7 @@ library PlasmaRLP {
         returns (exitingTx memory)
     {
         RLPDecode.RLPItem[] memory txList = RLPDecode.toList(RLPDecode.toRlpItem(exitingTxBytes));
+//    address payable exitor = RLPDecode.toAddress(txList[7 + 2 * oindex]);
         return exitingTx({
             exitor: RLPDecode.toAddress(txList[7 + 2 * oindex]),
             token: RLPDecode.toAddress(txList[6]),

--- a/plasma/root_chain/contracts/PlasmaRLP.sol
+++ b/plasma/root_chain/contracts/PlasmaRLP.sol
@@ -28,7 +28,7 @@ library PlasmaRLP {
 
     function createExitingTx(bytes memory exitingTxBytes, uint256 oindex)
         internal
-        returns (exitingTx)
+        returns (exitingTx memory)
     {
         var txList = RLPDecode.toList(RLPDecode.toRlpItem(exitingTxBytes));
         return exitingTx({

--- a/plasma/root_chain/contracts/PlasmaRLP.sol
+++ b/plasma/root_chain/contracts/PlasmaRLP.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 import "./RLPDecode.sol";
 

--- a/plasma/root_chain/contracts/PlasmaRLP.sol
+++ b/plasma/root_chain/contracts/PlasmaRLP.sol
@@ -31,7 +31,6 @@ library PlasmaRLP {
         returns (exitingTx memory)
     {
         RLPDecode.RLPItem[] memory txList = RLPDecode.toList(RLPDecode.toRlpItem(exitingTxBytes));
-//    address payable exitor = RLPDecode.toAddress(txList[7 + 2 * oindex]);
         return exitingTx({
             exitor: RLPDecode.toAddress(txList[7 + 2 * oindex]),
             token: RLPDecode.toAddress(txList[6]),

--- a/plasma/root_chain/contracts/PlasmaRLP.sol
+++ b/plasma/root_chain/contracts/PlasmaRLP.sol
@@ -18,7 +18,7 @@ library PlasmaRLP {
         internal
         returns (uint256)
     {
-        var txList = RLPDecode.toList(RLPDecode.toRlpItem(challengingTxBytes));
+        RLPDecode.RLPItem[] memory txList = RLPDecode.toList(RLPDecode.toRlpItem(challengingTxBytes));
         uint256 oIndexShift = oIndex * 3;
         return
             RLPDecode.toUint(txList[0 + oIndexShift]) * 1000000000 +
@@ -30,7 +30,7 @@ library PlasmaRLP {
         internal
         returns (exitingTx memory)
     {
-        var txList = RLPDecode.toList(RLPDecode.toRlpItem(exitingTxBytes));
+        RLPDecode.RLPItem[] memory txList = RLPDecode.toList(RLPDecode.toRlpItem(exitingTxBytes));
         return exitingTx({
             exitor: RLPDecode.toAddress(txList[7 + 2 * oindex]),
             token: RLPDecode.toAddress(txList[6]),

--- a/plasma/root_chain/contracts/PlasmaRLP.sol
+++ b/plasma/root_chain/contracts/PlasmaRLP.sol
@@ -16,7 +16,6 @@ library PlasmaRLP {
 
     function getUtxoPos(bytes memory challengingTxBytes, uint256 oIndex)
         internal
-        constant
         returns (uint256)
     {
         var txList = RLPDecode.toList(RLPDecode.toRlpItem(challengingTxBytes));
@@ -29,7 +28,6 @@ library PlasmaRLP {
 
     function createExitingTx(bytes memory exitingTxBytes, uint256 oindex)
         internal
-        constant
         returns (exitingTx)
     {
         var txList = RLPDecode.toList(RLPDecode.toRlpItem(exitingTxBytes));

--- a/plasma/root_chain/contracts/PriorityQueue.sol
+++ b/plasma/root_chain/contracts/PriorityQueue.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 import "./SafeMath.sol";
 

--- a/plasma/root_chain/contracts/RLPDecode.sol
+++ b/plasma/root_chain/contracts/RLPDecode.sol
@@ -176,7 +176,7 @@ library RLPDecode {
         return result;
     }
 
-    function toBytes(RLPItem memory item) internal pure returns (bytes) {
+    function toBytes(RLPItem memory item) internal pure returns (bytes memory) {
         uint offset = _payloadOffset(item.memPtr);
         uint len = item.len - offset; // data length
         bytes memory result = new bytes(len);

--- a/plasma/root_chain/contracts/RLPDecode.sol
+++ b/plasma/root_chain/contracts/RLPDecode.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/RLPDecode.sol
+++ b/plasma/root_chain/contracts/RLPDecode.sol
@@ -150,7 +150,7 @@ library RLPDecode {
         return result == 0 ? false : true;
     }
 
-    function toAddress(RLPItem memory item) internal pure returns (address) {
+    function toAddress(RLPItem memory item) internal pure returns (address payable) {
         // 1 byte for the length prefix according to RLP spec
         require(item.len == 21, "Item must be 21 characters long.");
         

--- a/plasma/root_chain/contracts/RLPEncode.sol
+++ b/plasma/root_chain/contracts/RLPEncode.sol
@@ -18,7 +18,7 @@ library RLPEncode {
      */
     function encodeBytes(bytes memory self) internal pure returns (bytes memory) {
         bytes memory encoded;
-        if (self.length == 1 && uint(self[0]) <= 128) {
+        if (self.length == 1 && uint8(self[0]) <= 128) {
             encoded = self;
         } else {
             encoded = concat(encodeLength(self.length, 128), self);
@@ -105,7 +105,7 @@ library RLPEncode {
         bytes memory encoded;
         if (len < 56) {
             encoded = new bytes(1);
-            encoded[0] = byte(len + offset);
+            encoded[0] = byte(uint8(len) + uint8(offset));
         } else {
             uint lenLen;
             uint i = 1;
@@ -115,9 +115,9 @@ library RLPEncode {
             }
 
             encoded = new bytes(lenLen + 1);
-            encoded[0] = byte(lenLen + offset + 55);
+            encoded[0] = byte(uint8(lenLen) + uint8(offset) + 55);
             for(i = 1; i <= lenLen; i++) {
-                encoded[i] = byte((len / (256**(lenLen-i))) % 256);
+                encoded[i] = byte(uint8((len / (256**(lenLen-i))) % 256));
             }
         }
         return encoded;

--- a/plasma/root_chain/contracts/RLPEncode.sol
+++ b/plasma/root_chain/contracts/RLPEncode.sol
@@ -16,7 +16,7 @@ library RLPEncode {
      * @param self The byte string to encode.
      * @return The RLP encoded string in bytes.
      */
-    function encodeBytes(bytes memory self) internal pure returns (bytes) {
+    function encodeBytes(bytes memory self) internal pure returns (bytes memory) {
         bytes memory encoded;
         if (self.length == 1 && uint(self[0]) <= 128) {
             encoded = self;
@@ -31,7 +31,7 @@ library RLPEncode {
      * @param self The list of RLP encoded byte strings.
      * @return The RLP encoded list of items in bytes.
      */
-    function encodeList(bytes[] memory self) internal pure returns (bytes) {
+    function encodeList(bytes[] memory self) internal pure returns (bytes memory) {
         bytes memory list = flatten(self);
         return concat(encodeLength(list.length, 192), list);
     }
@@ -41,7 +41,7 @@ library RLPEncode {
      * @param self The string to encode.
      * @return The RLP encoded string in bytes.
      */
-    function encodeString(string memory self) internal pure returns (bytes) {
+    function encodeString(string memory self) internal pure returns (bytes memory) {
         return encodeBytes(bytes(self));
     }
 
@@ -50,7 +50,7 @@ library RLPEncode {
      * @param self The address to encode.
      * @return The RLP encoded address in bytes.
      */
-    function encodeAddress(address self) internal pure returns (bytes) {
+    function encodeAddress(address self) internal pure returns (bytes memory) {
         bytes memory inputBytes;
         assembly {
             let m := mload(0x40)
@@ -66,7 +66,7 @@ library RLPEncode {
      * @param self The uint to encode.
      * @return The RLP encoded uint in bytes.
      */
-    function encodeUint(uint self) internal pure returns (bytes) {
+    function encodeUint(uint self) internal pure returns (bytes memory) {
         return encodeBytes(toBinary(self));
     }
 
@@ -75,7 +75,7 @@ library RLPEncode {
      * @param self The int to encode.
      * @return The RLP encoded int in bytes.
      */
-    function encodeInt(int self) internal pure returns (bytes) {
+    function encodeInt(int self) internal pure returns (bytes memory) {
         return encodeUint(uint(self));
     }
 
@@ -84,7 +84,7 @@ library RLPEncode {
      * @param self The bool to encode.
      * @return The RLP encoded bool in bytes.
      */
-    function encodeBool(bool self) internal pure returns (bytes) {
+    function encodeBool(bool self) internal pure returns (bytes memory) {
         bytes memory encoded = new bytes(1);
         encoded[0] = (self ? bytes1(0x01) : bytes1(0x80));
         return encoded;
@@ -101,7 +101,7 @@ library RLPEncode {
      * @param offset 128 if item is string, 192 if item is list.
      * @return RLP encoded bytes.
      */
-    function encodeLength(uint len, uint offset) private pure returns (bytes) {
+    function encodeLength(uint len, uint offset) private pure returns (bytes memory) {
         bytes memory encoded;
         if (len < 56) {
             encoded = new bytes(1);
@@ -129,7 +129,7 @@ library RLPEncode {
      * @param _x The integer to encode.
      * @return RLP encoded bytes.
      */
-    function toBinary(uint _x) private pure returns (bytes) {
+    function toBinary(uint _x) private pure returns (bytes memory) {
         bytes memory b = new bytes(32);
         assembly { 
             mstore(add(b, 32), _x) 
@@ -180,7 +180,7 @@ library RLPEncode {
      * @param _list List of byte strings to flatten.
      * @return The flattened byte string.
      */
-    function flatten(bytes[] memory _list) private pure returns (bytes) {
+    function flatten(bytes[] memory _list) private pure returns (bytes memory) {
         if (_list.length == 0) {
             return new bytes(0);
         }
@@ -214,7 +214,7 @@ library RLPEncode {
      * @param _postBytes Second byte string.
      * @return Both byte string combined.
      */
-    function concat(bytes memory _preBytes, bytes memory _postBytes) private pure returns (bytes) {
+    function concat(bytes memory _preBytes, bytes memory _postBytes) private pure returns (bytes memory) {
         bytes memory tempBytes;
 
         assembly {

--- a/plasma/root_chain/contracts/RLPEncode.sol
+++ b/plasma/root_chain/contracts/RLPEncode.sol
@@ -134,7 +134,8 @@ library RLPEncode {
         assembly { 
             mstore(add(b, 32), _x) 
         }
-        for (uint i = 0; i < 32; i++) {
+        uint i = 0;
+        for (; i < 32; i++) {
             if (b[i] != 0) {
                 break;
             }
@@ -186,7 +187,8 @@ library RLPEncode {
         }
 
         uint len;
-        for (uint i = 0; i < _list.length; i++) {
+        uint i = 0;
+        for (; i < _list.length; i++) {
             len += _list[i].length;
         }
 

--- a/plasma/root_chain/contracts/RLPEncode.sol
+++ b/plasma/root_chain/contracts/RLPEncode.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain.sol
@@ -64,7 +64,7 @@ contract RootChain {
     mapping (address => address) public exitsQueues;
 
     struct Exit {
-        address owner;
+        address payable owner;
         address token;
         uint256 amount;
     }
@@ -334,7 +334,7 @@ contract RootChain {
      */
     function addExitToQueue(
         uint256 _utxoPos,
-        address _exitor,
+        address payable _exitor,
         address _token,
         uint256 _amount,
         uint256 _created_at

--- a/plasma/root_chain/contracts/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain.sol
@@ -189,9 +189,9 @@ contract RootChain {
      */
     function startExit(
         uint256 _utxoPos,
-        bytes _txBytes,
-        bytes _proof,
-        bytes _sigs
+        bytes memory _txBytes,
+        bytes memory _proof,
+        bytes memory _sigs
     )
         public payable onlyWithValue(EXIT_BOND)
     {
@@ -224,10 +224,10 @@ contract RootChain {
     function challengeExit(
         uint256 _cUtxoPos,
         uint256 _eUtxoIndex,
-        bytes _txBytes,
-        bytes _proof,
-        bytes _sigs,
-        bytes _confirmationSig
+        bytes memory _txBytes,
+        bytes memory _proof,
+        bytes memory _sigs,
+        bytes memory _confirmationSig
     )
         public
     {

--- a/plasma/root_chain/contracts/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain.sol
@@ -164,7 +164,7 @@ contract RootChain {
 
         // Validate the given owner and amount.
         bytes32 root = plasmaBlocks[blknum].root;
-        bytes32 depositHash = keccak256(msg.sender, _token, _amount);
+        bytes32 depositHash = keccak256(abi.encodePacked(msg.sender, _token, _amount));
         require(root == depositHash, "Root hash must match deposit hash.");
 
         addExitToQueue(_depositPos, msg.sender, _token, _amount, plasmaBlocks[blknum].timestamp);
@@ -205,7 +205,7 @@ contract RootChain {
 
         // Check the transaction was included in the chain and is correctly signed.
         bytes32 root = plasmaBlocks[blknum].root;
-        bytes32 merkleHash = keccak256(keccak256(_txBytes), ByteUtils.slice(_sigs, 0, 130));
+        bytes32 merkleHash = keccak256(abi.encodePacked(keccak256(_txBytes), ByteUtils.slice(_sigs, 0, 130)));
         require(Validate.checkSigs(keccak256(_txBytes), root, exitingTx.inputCount, _sigs), "Signatures must match.");
         require(merkleHash.checkMembership(txindex, root, _proof), "Transaction Merkle proof is invalid.");
 
@@ -235,8 +235,8 @@ contract RootChain {
         uint256 txindex = (_cUtxoPos % 1000000000) / 10000;
         bytes32 root = plasmaBlocks[_cUtxoPos / 1000000000].root;
         bytes32 txHash = keccak256(_txBytes);
-        bytes32 confirmationHash = keccak256(txHash, root);
-        bytes32 merkleHash = keccak256(txHash, _sigs);
+        bytes32 confirmationHash = keccak256(abi.encodePacked(txHash, root));
+        bytes32 merkleHash = keccak256(abi.encodePacked(txHash, _sigs));
         address owner = exits[eUtxoPos].owner;
 
         // Validate the spending transaction.

--- a/plasma/root_chain/contracts/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain.sol
@@ -200,7 +200,7 @@ contract RootChain {
         uint256 oindex = _utxoPos - blknum * 1000000000 - txindex * 10000;
 
         // Check the sender owns this UTXO.
-        var exitingTx = _txBytes.createExitingTx(oindex);
+        PlasmaRLP.exitingTx memory exitingTx = _txBytes.createExitingTx(oindex);
         require(msg.sender == exitingTx.exitor, "Sender must be exitor.");
 
         // Check the transaction was included in the chain and is correctly signed.
@@ -234,9 +234,9 @@ contract RootChain {
         uint256 eUtxoPos = _txBytes.getUtxoPos(_eUtxoIndex);
         uint256 txindex = (_cUtxoPos % 1000000000) / 10000;
         bytes32 root = plasmaBlocks[_cUtxoPos / 1000000000].root;
-        var txHash = keccak256(_txBytes);
-        var confirmationHash = keccak256(txHash, root);
-        var merkleHash = keccak256(txHash, _sigs);
+        bytes32 txHash = keccak256(_txBytes);
+        bytes32 confirmationHash = keccak256(txHash, root);
+        bytes32 merkleHash = keccak256(txHash, _sigs);
         address owner = exits[eUtxoPos].owner;
 
         // Validate the spending transaction.

--- a/plasma/root_chain/contracts/RootChain.sol
+++ b/plasma/root_chain/contracts/RootChain.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 import "./SafeMath.sol";
 import "./Math.sol";

--- a/plasma/root_chain/contracts/SafeMath.sol
+++ b/plasma/root_chain/contracts/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/plasma/root_chain/contracts/Validate.sol
+++ b/plasma/root_chain/contracts/Validate.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.0;
 
 import "./ByteUtils.sol";
 import "./ECRecovery.sol";

--- a/plasma/root_chain/contracts/Validate.sol
+++ b/plasma/root_chain/contracts/Validate.sol
@@ -9,7 +9,7 @@ import "./ECRecovery.sol";
  * @dev Checks that the signatures on a transaction are valid
  */
 library Validate {
-    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 blknum2, bytes sigs)
+    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 blknum2, bytes memory sigs)
         internal
         view
         returns (bool)

--- a/plasma/root_chain/contracts/Validate.sol
+++ b/plasma/root_chain/contracts/Validate.sol
@@ -18,7 +18,7 @@ library Validate {
         bytes memory sig1 = ByteUtils.slice(sigs, 0, 65);
         bytes memory sig2 = ByteUtils.slice(sigs, 65, 65);
         bytes memory confSig1 = ByteUtils.slice(sigs, 130, 65);
-        bytes32 confirmationHash = keccak256(txHash, rootHash);
+        bytes32 confirmationHash = keccak256(abi.encodePacked(txHash, rootHash));
 
         bool check1 = true;
         bool check2 = true;

--- a/tests/root_chain/contracts/root_chain/test_root_chain.py
+++ b/tests/root_chain/contracts/root_chain/test_root_chain.py
@@ -209,7 +209,7 @@ def test_finalize_exits(t, u, root_chain):
     t.chain.head_state.timestamp += two_weeks * 2
     assert root_chain.exits(utxo_pos1) == ['0x' + owner.hex(), NULL_ADDRESS_HEX, 100]
     pre_balance = t.chain.head_state.get_balance(owner)
-    root_chain.finalizeExits(sender=t.k2)
+    root_chain.finalizeExits(NULL_ADDRESS, sender=t.k2)
     post_balance = t.chain.head_state.get_balance(owner)
     assert post_balance == pre_balance + value_1 + exit_bond
     assert root_chain.exits(utxo_pos1) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, value_1]


### PR DESCRIPTION
Solidity v0.5 has been released on 14 Nov 2018 and current version is [v0.5.4](https://github.com/ethereum/solidity/releases/tag/v0.5.4). 😎 

- [Release Version 0.5.0 · ethereum/solidity](https://github.com/ethereum/solidity/releases/tag/v0.5.0)
- [Solidity v0.5.0 Breaking Changes — Solidity 0.5.5 documentation](https://solidity.readthedocs.io/en/latest/050-breaking-changes.html)